### PR TITLE
chore: ignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ target
 
 # Claude Code
 .claude/*.local.json
+.claude/scheduled_tasks.lock
 .claude/skills/lib-*/SKILL.md
 .claude/skills/tool-*/SKILL.md
 


### PR DESCRIPTION
## 概要

- `.claude/scheduled_tasks.lock` を `.gitignore` の Claude Code セクションに追加。
- スケジュールタスクのロックファイルは一時的なプロセス状態であり、リポジトリに含める必要がない。

## テスト計画

- [x] `mise run pre-commit` (fmt:check, clippy:strict, ast-grep, lint:gh) パス
- [x] `mise run test` 全 41 テストパス
- [x] `mise run coverage` 92.61% (閾値 90% 超過)
- [x] `mise run build:release` 成功
- [ ] GitHub Actions CI パス