### PR TITLE
chore: update gh-sync and switch to merge-commit-only strategy

### DIFF
--- a/.github/gh-sync/config.yaml
+++ b/.github/gh-sync/config.yaml
@@ -263,7 +263,7 @@ spec:
         non_fast_forward: true
         deletion: true
         creation: false
-        required_linear_history: true
+        required_linear_history: false
         required_signatures: true
 files:
   # .cargo

--- a/.github/gh-sync/config.yaml
+++ b/.github/gh-sync/config.yaml
@@ -12,16 +12,16 @@ spec:
     discussions: false
   web_commit_signoff_required: true
   merge_strategy:
-    allow_merge_commit: false
-    allow_squash_merge: true
-    allow_rebase_merge: true
+    allow_merge_commit: true
+    allow_squash_merge: false
+    allow_rebase_merge: false
     allow_auto_merge: true
     allow_update_branch: true
     auto_delete_head_branches: true
     squash_merge_commit_title: PR_TITLE
     squash_merge_commit_message: COMMIT_MESSAGES
-    merge_commit_title: MERGE_MESSAGE
-    merge_commit_message: PR_TITLE
+    merge_commit_title: PR_TITLE
+    merge_commit_message: BLANK
   release_immutability: true
   label_sync: mirror
   labels:
@@ -210,6 +210,10 @@ spec:
     - name: versioning:semver-coerced
       description: "Versioning: semver (coerced)"
       color: 14b8a6
+    - name: versioning:semver-partial
+      description: "Versioning: semver (partial)"
+      color: 14b8a6
+
   actions:
     enabled: true
     allowed_actions: selected
@@ -248,8 +252,7 @@ spec:
           require_last_push_approval: false
           required_review_thread_resolution: true
           allowed_merge_methods:
-            - squash
-            - rebase
+            - merge
         required_status_checks:
           strict_required_status_checks_policy: true
           contexts:

--- a/mise.toml
+++ b/mise.toml
@@ -11,7 +11,7 @@ OPENOBSERVE_VERSION = "v0.70.3"
 "aqua:taiki-e/cargo-llvm-cov" = "0.8.5"
 "aqua:watchexec/cargo-watch" = "8.5.3"
 "cargo:cargo-sweep" = "0.8.0"
-"github:naa0yama/gh-sync" = "0.2.0"
+"github:naa0yama/gh-sync" = "0.2.1"
 "github:rust-secure-code/cargo-auditable" = "0.7.4"
 actionlint = "1.7.12"
 codeql = { version = "latest", bin_path = "codeql", platforms = { linux-x64 = { asset_pattern = "codeql-linux64.zip" }, macos-arm64 = { asset_pattern = "codeql-osx64.zip" }, macos-x64 = { asset_pattern = "codeql-osx64.zip" }, windows-x64 = { asset_pattern = "codeql-win64.zip" } } }


### PR DESCRIPTION
## 概要

- `gh-sync` ツールを `0.2.0` から `0.2.1` にバージョンアップ
- マージ戦略を merge-commit のみに変更 (squash/rebase を無効化)
- `merge_commit_title` を `PR_TITLE`、`merge_commit_message` を `BLANK` に設定
- `allowed_merge_methods` を `merge` のみに変更
- `versioning:semver-partial` ラベルを追加

## テスト計画

- [ ] CI が通過することを確認
- [ ] gh-sync が新しいバージョンで正常に動作することを確認
- [ ] GitHub リポジトリ設定がマージ戦略変更後に正しく同期されることを確認