### PR TITLE
chore: switch to squash-merge-only strategy and update tagpr to v1.18.3

### DIFF
--- a/.github/gh-sync/config.yaml
+++ b/.github/gh-sync/config.yaml
@@ -12,8 +12,8 @@ spec:
     discussions: false
   web_commit_signoff_required: true
   merge_strategy:
-    allow_merge_commit: true
-    allow_squash_merge: false
+    allow_merge_commit: false
+    allow_squash_merge: true
     allow_rebase_merge: false
     allow_auto_merge: true
     allow_update_branch: true
@@ -252,7 +252,7 @@ spec:
           require_last_push_approval: false
           required_review_thread_resolution: true
           allowed_merge_methods:
-            - merge
+            - squash
         required_status_checks:
           strict_required_status_checks_policy: true
           contexts:
@@ -341,6 +341,12 @@ files:
     strategy: replace
   - path: .github/tagpr-template.md
     strategy: replace
+
+  # .github/gh-sync
+  - path: .github/gh-sync/config.yaml
+    strategy: delete
+  - path: .github/gh-sync/schema.json
+    strategy: delete
 
   # .github/rulesets
   - path: .github/rulesets/default_branch.json

--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -54,7 +54,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - id: tagpr
-        uses: Songmu/tagpr@9d0f650553240dab1fa907eca27e3fd5b586e538 # v1.18.1
+        uses: Songmu/tagpr@9bbb945b2fb025126186661e27d55485e3fc6df6 # v1.18.3
         env:
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Summary

- tagpr の release PR が merge commit でマージされた際、`ListPullRequestsWithCommit` API の GitHub インデックス遅延により tagpr がタグを作成できない問題を修正
- squash merge のみに戻すことで tagpr の PR 検出を確実にする
- tagpr action を v1.18.1 → v1.18.3 にバージョンアップ
- gh-sync config/schema を downstream リポジトリに同期しないよう除外設定を追加

## Changes

- `.github/gh-sync/config.yaml`: `allow_merge_commit: false` / `allow_squash_merge: true` / `allowed_merge_methods: squash` に変更、gh-sync ファイル自体を downstream から削除するエントリを追加
- `.github/workflows/tagpr.yaml`: `Songmu/tagpr` を v1.18.1 (SHA: `9d0f650`) → v1.18.3 (SHA: `9bbb945`) に更新

## Background

PR #364 で merge-commit-only に切り替えた結果、PR #366 (Release for v0.1.4) のマージ後に tagpr がタグを作成できなかった。tagpr は `ListPullRequestsWithCommit` API で merge commit SHA → PR の関連付けを検索するが、GitHub のインデックスに時間がかかるため tagpr の 6 秒のリトライウィンドウ内に応答が返らなかった。squash merge であれば squash commit SHA が即座に PR と関連付けられるため、この問題は発生しない。