### PR TITLE
fix(ci): add pre-tagpr wait step to handle GitHub commit-to-PR index lag

### DIFF
--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -32,7 +32,7 @@ jobs:
     permissions:
       contents: write # Required to create tags and update files
       pull-requests: write # Required to create and update pull requests
-      issues: write # Required to manage release issues
+      issues: read # Required to read release-related issues (tagpr official recommendation)
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -52,6 +52,33 @@ jobs:
           install_args: dprint rust
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Wait for GitHub commit-to-PR index to settle
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          # tagpr v1.18.3 has a built-in 6-second retry window for
+          # ListPullRequestsWithCommit, which is insufficient for this
+          # repo's squash-merge workflow. Poll up to 120s so that
+          # latestPullRequest() succeeds on its first attempt.
+          # Remove this step once Songmu/tagpr extends its retry window.
+          # ref: https://github.com/Songmu/tagpr/issues/330
+          for i in $(seq 1 24); do
+            count=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
+              --jq 'length' 2>/dev/null || echo 0)
+            if [ "${count}" -gt 0 ]; then
+              echo "commit-to-PR index ready after ${i} attempt(s)"
+              # exit 0 ends only this run: shell; the next step still runs.
+              exit 0
+            fi
+            echo "attempt ${i}/24: index not ready, sleeping 5s"
+            sleep 5
+          done
+          # HEAD may legitimately have no PR (direct push, workflow re-run).
+          # Let tagpr's own logic decide rather than failing the job.
+          echo "::warning::commit-to-PR index did not populate within 120s; proceeding"
 
       - id: tagpr
         uses: Songmu/tagpr@9bbb945b2fb025126186661e27d55485e3fc6df6 # v1.18.3


### PR DESCRIPTION
## Summary

- tagpr v1.18.3 の `ListPullRequestsWithCommit` リトライ窓 (3 × 2s = 6s) は、 squash merge 後の GitHub commit→PR インデックス遅延 (実測 10〜30s 超) に対して不足している
- `latestPullRequest()` が `(nil, nil)` を返すと `isTagPR(nil) = false` となり tagpr が release PR を再生成し続ける無限ループが発生する (Songmu/tagpr#330)
- tagpr step の直前に `commits/{sha}/pulls` を最大 120s ポーリングする wait step を追加し、 インデックスが反映されてから tagpr を実行するようにした
- `issues: write` → `read` に縮小 (tagpr 公式 README 推奨に準拠)

## Changes

- `.github/workflows/tagpr.yaml`: wait step 追加 (+26 行) + `issues: read` (-1/+1 行)

## Design choice

tagpr 公式 README / ドッグフード workflow は `push: main` trigger を推奨し `pull_request: closed` を使う event 分離パターンは存在しない。 upstream 準拠を維持する観点から wait step (A 案) を採用した。 tagpr が retry 窓を拡張した場合はこの step を削除するだけで良い。

## Test plan

- [ ] CI Gate (actionlint, clippy, tests) が通過すること
- [ ] この PR を squash merge した後、次回 release PR (`Release for v0.1.5`) が作成されること
- [ ] その release PR を squash merge したとき、 tagpr workflow の `Wait for GitHub commit-to-PR index to settle` step が 1〜3 attempt 以内で成功し `v0.1.5` タグ + Draft Release が自動作成されること