### PR TITLE
chore(gh-sync): add preserve_markers support for project-specific sections

### DIFF
--- a/.github/gh-sync/config.yaml
+++ b/.github/gh-sync/config.yaml
@@ -343,6 +343,8 @@ files:
     strategy: replace
 
   # .github/gh-sync
+  - path: .github/gh-sync/patches/.gitkeep
+    strategy: create_only
   - path: .github/gh-sync/config.yaml
     strategy: delete
   - path: .github/gh-sync/schema.json
@@ -395,6 +397,7 @@ files:
   # .vscode
   - path: .vscode/launch.json
     strategy: patch
+    preserve_markers: true
   - path: .vscode/settings.json
     strategy: replace
 
@@ -449,6 +452,7 @@ files:
     strategy: replace
   - path: Cargo.toml
     strategy: patch
+    preserve_markers: true
   - path: Dockerfile
     strategy: replace
   - path: LICENSE
@@ -459,6 +463,7 @@ files:
     strategy: replace
   - path: mise.toml
     strategy: patch
+    preserve_markers: true
   - path: renovate.json
     strategy: replace
   - path: rust-toolchain.toml

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,15 +7,21 @@
 		{
 			"type": "lldb",
 			"request": "launch",
+			// gh-sync:keep-start
 			"name": "Debug executable 'brust'",
+			// gh-sync:keep-end
 			"cargo": {
 				"args": [
 					"build",
+					// gh-sync:keep-start
 					"--bin=brust",
 					"--package=brust"
+					// gh-sync:keep-end
 				],
 				"filter": {
+					// gh-sync:keep-start
 					"name": "brust",
+					// gh-sync:keep-end
 					"kind": "bin"
 				}
 			},
@@ -25,16 +31,22 @@
 		{
 			"type": "lldb",
 			"request": "launch",
+			// gh-sync:keep-start
 			"name": "Debug unit tests in executable 'brust'",
+			// gh-sync:keep-end
 			"cargo": {
 				"args": [
 					"test",
 					"--no-run",
+					// gh-sync:keep-start
 					"--bin=brust",
 					"--package=brust"
+					// gh-sync:keep-end
 				],
 				"filter": {
+					// gh-sync:keep-start
 					"name": "brust",
+					// gh-sync:keep-end
 					"kind": "bin"
 				}
 			},

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@
 # -
 [workspace]
 resolver = "3"
+# gh-sync:keep-start
+# Project-specific dependencies are listed here.
+
 members = [
 	"crates/brust",
 ]
@@ -12,11 +15,17 @@ version = "0.1.5"
 edition = "2024"
 license = "AGPL-3.0-only"
 repository = "https://github.com/naa0yama/boilerplate-rust"
+# gh-sync:keep-end
 
 # - -------------------------------------------------------------------------------------------------
 # - Dependencies
 # -
 [workspace.dependencies]
+# gh-sync:keep-start
+# Project-specific dependencies are listed here.
+
+# gh-sync:keep-end
+
 # Core
 anyhow = "1.0"
 clap = { version = "4.5.45", default-features = false, features = ["std", "derive", "help", "usage", "error-context", "color", "suggestions"] }

--- a/mise.toml
+++ b/mise.toml
@@ -1,8 +1,13 @@
 [env]
 OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:5080/api/default"
-RUST_LOG = "warn,brust=trace"
 ## renovate: datasource=github-releases packageName=openobserve/openobserve versioning=semver automerge=true
 OPENOBSERVE_VERSION = "v0.70.3"
+
+# gh-sync:keep-start
+# Project-specific dependencies are listed here.
+
+RUST_LOG = "warn,brust=trace"
+# gh-sync:keep-end
 
 [tools]
 "aqua:ast-grep/ast-grep" = "0.42.1"


### PR DESCRIPTION
## 概要

gh-sync の `preserve_markers` 機能を有効化し、プロジェクト固有のセクションをテンプレート同期から保護する。

- `.github/gh-sync/config.yaml`: `.vscode/launch.json` / `Cargo.toml` / `mise.toml` に `preserve_markers: true` を追加、`patches/.gitkeep` を `create_only` で追加
- `.vscode/launch.json`: バイナリ名 (`brust`) などプロジェクト固有値を `gh-sync:keep-start/end` マーカーで保護
- `Cargo.toml`: workspace メンバー・パッケージメタデータを `gh-sync:keep-start/end` マーカーで保護
- `mise.toml`: `RUST_LOG` などのプロジェクト固有環境変数を `gh-sync:keep-start/end` マーカーで保護

## テスト計画

- [ ] pre-commit がパスすることを確認 (✅ ローカル確認済み)
- [ ] CI の全ステータスチェックがパスすることを確認