### PR TITLE
chore: disable publishing to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
 version = "0.1.5"
 edition = "2024"
 license = "AGPL-3.0-only"
+publish = false
 repository = "https://github.com/naa0yama/boilerplate-rust"
 # gh-sync:keep-end
 

--- a/crates/brust/Cargo.toml
+++ b/crates/brust/Cargo.toml
@@ -8,6 +8,7 @@ categories = ["command-line-utilities"]
 edition.workspace = true
 keywords = ["cli", "tool"]
 license.workspace = true
+publish.workspace = true
 repository.workspace = true
 description = "A CLI tool built following project rules standards"
 


### PR DESCRIPTION
## Summary

- `[workspace.package]` に `publish = false` を追加し、crates.io への誤った公開を防止
- `crates/brust/Cargo.toml` に `publish.workspace = true` を追加してワークスペース設定を継承

## Test plan

- [ ] `cargo metadata --no-deps` で `publish: []` が返ることを確認済み