### PR TITLE
chore: update gh-sync to v0.3.3 and add gh-sync-drift label

### DIFF
--- a/.github/gh-sync/config.yaml
+++ b/.github/gh-sync/config.yaml
@@ -95,6 +95,9 @@ spec:
     - name: tests
       description: Changes to test files
       color: "257759"
+    - name: gh-sync-drift
+      description: Changes to gh-sync drift
+      color: "257759"
 
     # Renovate — datasource
     - name: "datasource:"

--- a/mise.toml
+++ b/mise.toml
@@ -16,7 +16,7 @@ RUST_LOG = "warn,brust=trace"
 "aqua:taiki-e/cargo-llvm-cov" = "0.8.5"
 "aqua:watchexec/cargo-watch" = "8.5.3"
 "cargo:cargo-sweep" = "0.8.0"
-"github:naa0yama/gh-sync" = "0.3.0"
+"github:naa0yama/gh-sync" = "0.3.3"
 "github:rust-secure-code/cargo-auditable" = "0.7.4"
 actionlint = "1.7.12"
 codeql = { version = "latest", bin_path = "codeql", platforms = { linux-x64 = { asset_pattern = "codeql-linux64.zip" }, macos-arm64 = { asset_pattern = "codeql-osx64.zip" }, macos-x64 = { asset_pattern = "codeql-osx64.zip" }, windows-x64 = { asset_pattern = "codeql-win64.zip" } } }


### PR DESCRIPTION
## Summary

- `mise.toml` の `gh-sync` バージョンを `v0.3.0` から `v0.3.3` に更新
- `.github/gh-sync/config.yaml` に `gh-sync-drift` ラベルを追加

## Test plan

- [ ] pre-commit 通過確認済み (clippy, fmt, ast-grep, actionlint)
- [ ] CI の自動チェックが通ること