### PR TITLE
ci: suppress ci-gate on concurrency cancellation

### DIFF
--- a/.github/workflows/_orchestrator.yaml
+++ b/.github/workflows/_orchestrator.yaml
@@ -220,7 +220,12 @@ jobs:
 
   ci-gate:
     name: CI Gate
-    if: always() && github.event.action != 'closed'
+    # !contains(...,'cancelled') suppresses the gate when concurrency
+    # cancel-in-progress cancels upstream jobs; skipped != cancelled.
+    if: >-
+      !cancelled()
+      && !contains(needs.*.result, 'cancelled')
+      && github.event.action != 'closed'
     needs: [rust-ci, miri, audit, container, docs-ci, codeql, actionlint]
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## Summary

- `ci-gate` ジョブの `if:` 条件を `always()` から `!cancelled() && !contains(needs.*.result, 'cancelled')` に変更
- `concurrency: cancel-in-progress: true` により上流ジョブがキャンセルされた場合、`ci-gate` をスキップするよう修正
- キャンセルされた run がコミットに偽の "Fail X" ステータスを残すノイズを解消

## Test plan

- [ ] 新しい push で前の run がキャンセルされた場合、コミットに failure ステータスが付かないことを確認
- [ ] 通常の CI 実行 (失敗なし) で `CI Gate` が正常に pass することを確認
- [ ] 実際に失敗するジョブがある場合、`CI Gate` が failure を正しく報告することを確認