### PR TITLE
ci: split cleanup into a dedicated workflow

### DIFF
--- a/.github/gh-sync/config.yaml
+++ b/.github/gh-sync/config.yaml
@@ -374,6 +374,8 @@ files:
     strategy: replace
   - path: .github/workflows/actionlint-format.txt
     strategy: replace
+  - path: .github/workflows/cleanup.yaml
+    strategy: replace
   - path: .github/workflows/miri.yaml
     strategy: replace
   - path: .github/workflows/pr-labeler.yaml

--- a/.github/workflows/_orchestrator.yaml
+++ b/.github/workflows/_orchestrator.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
   schedule:
     - cron: "0 18 * * *" # daily at 03:00 JST
 
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   detect-changes:
     name: detect-changes
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -93,7 +93,6 @@ jobs:
       !cancelled()
       && (github.event_name == 'push'
           || (github.event_name == 'pull_request'
-              && github.event.action != 'closed'
               && needs.detect-changes.outputs.rust == 'true'))
     uses: ./.github/workflows/rust-ci.yaml
     permissions:
@@ -105,7 +104,6 @@ jobs:
     needs: detect-changes
     if: >-
       github.event_name == 'pull_request'
-      && github.event.action != 'closed'
       && needs.detect-changes.outputs.miri == 'true'
     uses: ./.github/workflows/miri.yaml
     permissions:
@@ -118,7 +116,6 @@ jobs:
     if: >-
       github.event_name == 'schedule'
       || (github.event_name == 'pull_request'
-          && github.event.action != 'closed'
           && needs.detect-changes.outputs.audit == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -135,7 +132,6 @@ jobs:
     needs: detect-changes
     if: >-
       github.event_name == 'pull_request'
-      && github.event.action != 'closed'
       && needs.detect-changes.outputs.container == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -155,7 +151,6 @@ jobs:
     needs: detect-changes
     if: >-
       github.event_name == 'pull_request'
-      && github.event.action != 'closed'
       && needs.detect-changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -172,7 +167,7 @@ jobs:
     if: >-
       github.event_name == 'push'
       || github.event_name == 'schedule'
-      || (github.event_name == 'pull_request' && github.event.action != 'closed')
+      || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -188,7 +183,7 @@ jobs:
     name: actionlint
     if: >-
       github.event_name == 'schedule'
-      || (github.event_name == 'pull_request' && github.event.action != 'closed')
+      || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -201,23 +196,6 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/act-actionlint
 
-  cleanup:
-    name: cleanup
-    if: >-
-      github.event_name == 'pull_request'
-      && github.event.action == 'closed'
-      && github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      actions: write # Required to manage GitHub Actions artifacts
-      packages: write # Required to delete package versions
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/act-cleanup
-
   ci-gate:
     name: CI Gate
     # !contains(...,'cancelled') suppresses the gate when concurrency
@@ -225,7 +203,6 @@ jobs:
     if: >-
       !cancelled()
       && !contains(needs.*.result, 'cancelled')
-      && github.event.action != 'closed'
     needs: [rust-ci, miri, audit, container, docs-ci, codeql, actionlint]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Cleanup
+on:
+  pull_request:
+    types: [closed]
+
+permissions: {}
+
+concurrency:
+  group: cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false # zizmor: ignore[concurrency-limits] cleanup must run to completion after merge
+
+jobs:
+  cleanup:
+    name: cleanup
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: write # Required to manage GitHub Actions artifacts
+      packages: write # Required to delete package versions
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/act-cleanup


### PR DESCRIPTION
## Summary

- PR マージ後にマージコミットへ fail X が表示される問題を修正
- `cleanup` ジョブを `_orchestrator.yaml` から独立した `cleanup.yaml` へ分離
- `tagpr` の push によって PR-closed ランがキャンセルされるのを根本から解消

## 変更内容

### `_orchestrator.yaml`
- `pull_request: types` から `closed` を削除 (closed イベントはこのワークフローで扱わない)
- `cleanup` ジョブを削除
- 不要になった `action != 'closed'` ガードをすべて除去

### `cleanup.yaml` (新規)
- `pull_request: types: [closed]` のみをトリガーとする専用ワークフロー
- `concurrency: cleanup-{PR番号}` + `cancel-in-progress: false` で他ワークフローの concurrency と完全分離
- マージされた PR のみ実行 (`merged == true` ガード)

### `gh-sync/config.yaml`
- `cleanup.yaml` エントリを追加 (下流リポジトリへの同期対象に登録)

## Test plan

- [ ] CI Gate が `opened`/`synchronize` で従来通りパスすること
- [ ] この PR マージ後に独立した `Cleanup` ワークフローランが表示・成功すること
- [ ] マージコミットに fail X が表示されないこと