### PR TITLE
chore(deps): update gh-sync to v0.3.5

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -16,7 +16,7 @@ RUST_LOG = "warn,brust=trace"
 "aqua:taiki-e/cargo-llvm-cov" = "0.8.5"
 "aqua:watchexec/cargo-watch" = "8.5.3"
 "cargo:cargo-sweep" = "0.8.0"
-"github:naa0yama/gh-sync" = "0.3.4"
+"github:naa0yama/gh-sync" = "0.3.5"
 "github:rust-secure-code/cargo-auditable" = "0.7.4"
 actionlint = "1.7.12"
 codeql = { version = "latest", bin_path = "codeql", platforms = { linux-x64 = { asset_pattern = "codeql-linux64.zip" }, macos-arm64 = { asset_pattern = "codeql-osx64.zip" }, macos-x64 = { asset_pattern = "codeql-osx64.zip" }, windows-x64 = { asset_pattern = "codeql-win64.zip" } } }


### PR DESCRIPTION
## 概要

- `mise.toml` の `gh-sync` バージョンを `0.3.4` から `0.3.5` へ更新

## テスト計画

- [x] `mise run pre-commit` パス
- [x] 全テスト (29 unit + 12 integration) パス
- [x] `mise run build:release` パス
- [x] カバレッジ計測パス (全体 92.61%)