### PR TITLE
fix(ci): pin mise to v2026.4.18 and fix task_config.includes order

### DIFF
--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -35,11 +35,21 @@ else
 	echo "All mounts validated successfully!"
 fi
 
-# mise bootstrap: install into shared volume if not already present
+# mise bootstrap: install or upgrade to pinned version
 export PATH="$HOME/.local/bin:$PATH"
-if ! command -v mise > /dev/null 2>&1; then
-	echo "Installing mise..."
-	curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused https://mise.jdx.dev/install.sh | sh
+## renovate: datasource=github-releases packageName=jdx/mise versioning=calver:YYYY.M.D automerge=true
+MISE_PINNED_VERSION="2026.4.18"
+
+installed_version=""
+if command -v mise > /dev/null 2>&1; then
+	installed_version="$(mise --version | awk '{print $1}')"
+fi
+
+if [ "$installed_version" != "$MISE_PINNED_VERSION" ]; then
+	echo "Installing mise v${MISE_PINNED_VERSION} (installed: ${installed_version:-none})..."
+	MISE_VERSION="v${MISE_PINNED_VERSION}" \
+		curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused \
+		https://mise.jdx.dev/install.sh | sh
 fi
 mise --version
 

--- a/.github/workflows/_orchestrator.yaml
+++ b/.github/workflows/_orchestrator.yaml
@@ -169,7 +169,7 @@ jobs:
       || github.event_name == 'schedule'
       || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read # Required to checkout the repository for CodeQL analysis
       security-events: write # Required to upload CodeQL analysis results

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -126,6 +126,8 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           cache: false
+          # renovate: datasource=github-releases packageName=jdx/mise versioning=calver:YYYY.M.D automerge=true
+          version: 2026.4.18
 
       - name: Check formatting
         run: |
@@ -268,6 +270,8 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           cache: false
+          # renovate: datasource=github-releases packageName=jdx/mise versioning=calver:YYYY.M.D automerge=true
+          version: 2026.4.18
 
       - name: Generate coverage report
         run: |

--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -50,6 +50,8 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install_args: dprint rust
+          # renovate: datasource=github-releases packageName=jdx/mise versioning=calver:YYYY.M.D automerge=true
+          version: 2026.4.18
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/.mise/overrides.toml
+++ b/.mise/overrides.toml
@@ -1,3 +1,3 @@
 # Project-specific task overrides.
 # Tasks defined here take precedence over tasks.toml because this file
-# appears FIRST in the task_config.includes array in mise.toml.
+# appears LAST in the task_config.includes array in mise.toml.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ repository = "https://github.com/naa0yama/boilerplate-rust"
 # gh-sync:keep-start
 # Project-specific dependencies are listed here.
 
+## Core
+clap = { version = "4.5.45", default-features = false, features = ["std", "derive", "help", "usage", "error-context", "color", "suggestions"] }
+
 ## Data
 reqwest = { version = "0.13.1", default-features = false, features = ["blocking", "rustls-no-provider"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
@@ -38,7 +41,6 @@ rand = { version = "0.10", default-features = false, features = ["thread_rng"] }
 
 ## Core
 anyhow = "1.0"
-clap = { version = "4.5.45", default-features = false, features = ["std", "derive", "help", "usage", "error-context", "color", "suggestions"] }
 
 ## Logging
 tracing = "0.1.41"

--- a/mise.toml
+++ b/mise.toml
@@ -26,4 +26,4 @@ usage = "3.2.0"
 zizmor = "1.16.0"
 
 [task_config]
-includes = [".mise/overrides.toml", ".mise/tasks.toml"]
+includes = [".mise/tasks.toml", ".mise/overrides.toml"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,8 @@
 [toolchain]
+# gh-sync:keep-start
 channel = "1.94.0"
+# gh-sync:keep-end
+
 components = [
 	"cargo",
 	"clippy",
@@ -11,5 +14,7 @@ components = [
 ]
 targets = [
 	"x86_64-unknown-linux-gnu",
+	# gh-sync:keep-start
+	# gh-sync:keep-end
 ]
 profile = "default"


### PR DESCRIPTION
## Summary

- `mise >= 2026.4.9` (PR #9039) で `task_config.includes` の last-wins 優先順位が復活したため、`overrides.toml` が LAST になるよう `mise.toml` の includes 順序を修正
- devcontainer (`postStartCommand.sh`) と GitHub Actions (`rust-ci.yaml` x2, `tagpr.yaml` x1) で mise CLI バージョンを `v2026.4.18` に統一固定
- Renovate が自動バンプできるよう `# renovate:` アノテーションを追加 (`versioning=calver:YYYY.M.D`)
- `.mise/overrides.toml` のコメントを `FIRST` → `LAST` に修正
- `naa0yama/renovate-config` に shell-regex / github-actions-regex カスタムマネージャーを追加済み (PR #2343 マージ済み)

## Changes

- `mise.toml`: `task_config.includes` 順序を `[tasks.toml, overrides.toml]` に変更
- `.mise/overrides.toml`: コメント修正
- `.devcontainer/postStartCommand.sh`: バージョン固定 + Docker volume キャッシュ対応のアップグレードガード追加
- `.github/workflows/rust-ci.yaml`: `jdx/mise-action` に `version: 2026.4.18` を 2 箇所追加
- `.github/workflows/tagpr.yaml`: `jdx/mise-action` に `version: 2026.4.18` を追加
- `.github/workflows/_orchestrator.yaml`: CodeQL タイムアウトを 30 分に延長
- `Cargo.toml` / `rust-toolchain.toml`: `gh-sync:keep` マーカー追加

## Test plan

- [ ] CI (fmt / cross-check / test) が全て green になること
- [ ] coverage が ~98% であること (overrides.toml の `--exclude` が正しく適用されること)
- [ ] Renovate が `jdx/mise` の 4 箇所を同一 PR にグルーピングすること