### PR TITLE
chore: enable gh-sync preserve_markers for Dockerfile and rust-toolchain.toml

### DIFF
--- a/.github/gh-sync/config.yaml
+++ b/.github/gh-sync/config.yaml
@@ -460,6 +460,7 @@ files:
     preserve_markers: true
   - path: Dockerfile
     strategy: replace
+    preserve_markers: true
   - path: LICENSE
     strategy: replace
   - path: deny.toml
@@ -473,6 +474,7 @@ files:
     strategy: replace
   - path: rust-toolchain.toml
     strategy: replace
+    preserve_markers: true
   - path: sgconfig.yml
     strategy: replace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 	sudo \
 	wget
 
+# gh-sync:keep-start
+# Project-specific dependencies are listed here.
+
+# gh-sync:keep-end
+
 RUN echo "**** Create user ****" && \
 	set -euxo pipefail && \
 	groupadd --gid "${USER_GID}" "${USER_NAME}" && \


### PR DESCRIPTION
## 概要

- `gh-sync` の `config.yaml` で `Dockerfile` と `rust-toolchain.toml` に `preserve_markers: true` を追加
- `Dockerfile` に `gh-sync:keep-start` / `gh-sync:keep-end` ブロックを追加し、プロジェクト固有の依存パッケージを記述できるようにした

## 変更内容

- `.github/gh-sync/config.yaml`: `Dockerfile` と `rust-toolchain.toml` の sync 設定に `preserve_markers: true` を追加
- `Dockerfile`: `apt-get install` の後に keep ブロックマーカーを追加

## テスト

- [x] `mise run pre-commit` パス