### PR TITLE
chore: remove gh-sync keep markers from rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,5 @@
 [toolchain]
-# gh-sync:keep-start
 channel = "1.94.0"
-# gh-sync:keep-end
 
 components = [
 	"cargo",


### PR DESCRIPTION
## 概要

- `rust-toolchain.toml` から `gh-sync:keep-start` / `gh-sync:keep-end` マーカーを削除

## 変更内容

- `channel = "1.94.0"` を囲んでいた keep マーカーコメントを削除
- 機能的な変更はなし

## テスト

- [x] `mise run pre-commit` パス