### PR TITLE
chore(gh-sync): update to v0.3.6 and add preserve_markers

### DIFF
--- a/.github/gh-sync/config.yaml
+++ b/.github/gh-sync/config.yaml
@@ -457,6 +457,7 @@ files:
     strategy: replace
   - path: .gitignore
     strategy: replace
+    preserve_markers: true
   - path: .gitleaksignore
     strategy: replace
   - path: .octocov.yml
@@ -465,6 +466,7 @@ files:
     strategy: replace
   - path: .worktreeinclude
     strategy: replace
+    preserve_markers: true
   - path: Cargo.toml
     strategy: replace
     preserve_markers: true

--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,9 @@ src-tauri/gen/
 *.msi
 *.nsis
 
+# gh-sync:keep-start
+# Project-specific dependencies are listed here.
+
+# gh-sync:keep-end
+
 # Under the unknown

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -4,3 +4,8 @@
 
 # o2
 .mcp.json
+
+# gh-sync:keep-start
+# Project-specific dependencies are listed here.
+
+# gh-sync:keep-end

--- a/Dockerfile
+++ b/Dockerfile
@@ -186,3 +186,8 @@ alias cc="claude --dangerously-skip-permissions"
 
 _DOC_
 EOF
+
+# gh-sync:keep-start
+# Project-specific dependencies are listed here.
+
+# gh-sync:keep-end

--- a/mise.toml
+++ b/mise.toml
@@ -16,7 +16,7 @@ RUST_LOG = "warn,brust=trace"
 "aqua:taiki-e/cargo-llvm-cov" = "0.8.5"
 "aqua:watchexec/cargo-watch" = "8.5.3"
 "cargo:cargo-sweep" = "0.8.0"
-"github:naa0yama/gh-sync" = "0.3.5"
+"github:naa0yama/gh-sync" = "0.3.6"
 "github:rust-secure-code/cargo-auditable" = "0.7.4"
 actionlint = "1.7.12"
 codeql = { version = "latest", bin_path = "codeql", platforms = { linux-x64 = { asset_pattern = "codeql-linux64.zip" }, macos-arm64 = { asset_pattern = "codeql-osx64.zip" }, macos-x64 = { asset_pattern = "codeql-osx64.zip" }, windows-x64 = { asset_pattern = "codeql-win64.zip" } } }


### PR DESCRIPTION
## 概要

- `mise.toml`: gh-sync を `v0.3.5` から `v0.3.6` にバンプ
- `.gitignore`, `.worktreeinclude`, `Dockerfile`: `gh-sync:keep-start` / `gh-sync:keep-end` マーカーブロックを追加
- `.github/gh-sync/config.yaml`: `.gitignore` と `.worktreeinclude` に `preserve_markers: true` を追加し、次回の gh-sync 実行時にマーカーブロックが上書きされないよう設定

## テスト計画

- [ ] `mise run pre-commit` が通ること
- [ ] `mise run test` が通ること
- [ ] gh-sync 実行後に `.gitignore` / `.worktreeinclude` のマーカーブロックが保持されること