### PR TITLE
feat(otel): add gethostname-based service.instance.id and TraceContextPropagator

### DIFF
--- a/.claude/skills/project-conventions/references/module-and-project-structure.md
+++ b/.claude/skills/project-conventions/references/module-and-project-structure.md
@@ -19,19 +19,30 @@ ast-rules/
 
 ## OTel / Tracing Setup
 
-- OTel is enabled by default (`default = ["otel"]`).
+- OTel is enabled by default (`default = ["otel", "process-metrics"]`).
 - Set `OTEL_EXPORTER_OTLP_ENDPOINT` env var to activate OTLP export.
 - Without the env var (or empty), only the `fmt` layer is active.
 - Build without OTel: `mise run build -- --no-default-features`.
 - Test tasks automatically set `OTEL_EXPORTER_OTLP_ENDPOINT=""` to prevent OTel panics.
-- Feature flag in `Cargo.toml`:
+- Feature flags in `Cargo.toml`:
   ```toml
   [features]
-  default = ["otel"]
+  default = ["otel", "process-metrics"]
   otel = [
+  	"dep:gethostname",
   	"dep:opentelemetry",
   	"dep:opentelemetry_sdk",
   	"dep:opentelemetry-otlp",
   	"dep:tracing-opentelemetry",
+  	"dep:opentelemetry-appender-tracing",
+  	"dep:opentelemetry-semantic-conventions",
+  ]
+  # Collects OTel-semconv process metrics. Requires `otel`. Disable with --no-default-features.
+  process-metrics = [
+  	"otel",
+  	"dep:sysinfo",
   ]
   ```
+- `service.instance.id` is set to `gethostname::gethostname()` (CLI: one instance per host).
+- `TraceContextPropagator` and `global::set_tracer_provider()` are set at provider init.
+- Transport: HTTP/proto (`http-proto` + `reqwest-blocking-client`), port 4318.

--- a/.devcontainer/initializeCommand.sh
+++ b/.devcontainer/initializeCommand.sh
@@ -12,3 +12,8 @@ touch \
 	~/.claude.json \
 	~/.claude/.config.json \
 	~/.gitconfig
+
+# gh-sync:keep-start
+# Project-specific dependencies are listed here.
+
+# gh-sync:keep-end

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -66,3 +66,8 @@ wait
 
 echo "Starting OpenObserve..."
 mise run o2
+
+# gh-sync:keep-start
+# Project-specific dependencies are listed here.
+
+# gh-sync:keep-end

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "gethostname",
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
@@ -425,6 +426,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3655aa6818d65bc620d6911f05aa7b6aeb596291e1e9f79e52df85583d1e30"
+dependencies = [
+ "rustix 0.38.44",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -813,6 +824,12 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1322,6 +1339,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1329,7 +1359,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1629,7 +1659,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,9 +1427,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ sysinfo = { version = "0.38", default-features = false, features = ["system"] }
 ## semconv_experimental: enables process.* metric name constants (currently experimental)
 opentelemetry-semantic-conventions = { version = "0.31", default-features = false, features = ["semconv_experimental"] }
 
+## Hostname (optional, behind `otel` feature)
+gethostname = "0.5"
+
 ## OpenTelemetry (optional, behind `otel` feature)
 opentelemetry = { version = "0.31", default-features = false, features = ["trace", "metrics", "logs"] }
 opentelemetry-appender-tracing = { version = "0.31", default-features = false }

--- a/crates/brust/Cargo.toml
+++ b/crates/brust/Cargo.toml
@@ -28,6 +28,7 @@ pkg-fmt = "zip"
 [features]
 default = ["otel", "process-metrics"]
 otel = [
+	"dep:gethostname",
 	"dep:opentelemetry",
 	"dep:opentelemetry_sdk",
 	"dep:opentelemetry-otlp",
@@ -68,6 +69,9 @@ sysinfo = { workspace = true, optional = true }
 
 # OpenTelemetry semantic conventions (optional, behind `process-metrics` feature)
 opentelemetry-semantic-conventions = { workspace = true, optional = true }
+
+# Hostname (optional, behind `otel` feature)
+gethostname = { workspace = true, optional = true }
 
 # OpenTelemetry (optional, behind `otel` feature)
 opentelemetry = { workspace = true, optional = true }

--- a/crates/brust/src/libs/http.rs
+++ b/crates/brust/src/libs/http.rs
@@ -20,6 +20,13 @@ use crate::telemetry::metrics::Meters;
 ///
 /// Returns an error if the URL is invalid, the TCP connection fails, the server
 /// returns a network-level error, or the response body cannot be read.
+#[cfg_attr(
+    feature = "otel",
+    tracing::instrument(
+        skip(meters),
+        fields(otel.kind = ?opentelemetry::trace::SpanKind::Client)
+    )
+)]
 pub fn fetch_url(url: &str, meters: &Meters) -> anyhow::Result<()> {
     let parsed = reqwest::Url::parse(url).context("invalid URL")?;
     let host = parsed.host_str().unwrap_or("unknown").to_owned();

--- a/crates/brust/src/main.rs
+++ b/crates/brust/src/main.rs
@@ -108,6 +108,10 @@ fn build_resource() -> opentelemetry_sdk::Resource {
                 env!("CARGO_PKG_VERSION"),
             ),
             opentelemetry::KeyValue::new(
+                opentelemetry_semantic_conventions::attribute::SERVICE_INSTANCE_ID,
+                gethostname::gethostname().to_string_lossy().into_owned(),
+            ),
+            opentelemetry::KeyValue::new(
                 opentelemetry_semantic_conventions::attribute::VCS_REF_HEAD_REVISION,
                 env!("GIT_HASH"),
             ),
@@ -139,6 +143,10 @@ fn init_otel() -> OtelProviders {
                     .with_resource(resource.clone())
                     .with_batch_exporter(span_exporter)
                     .build();
+                opentelemetry::global::set_text_map_propagator(
+                    opentelemetry_sdk::propagation::TraceContextPropagator::new(),
+                );
+                opentelemetry::global::set_tracer_provider(tracer_provider.clone());
                 let tracer = opentelemetry::trace::TracerProvider::tracer(
                     &tracer_provider,
                     env!("CARGO_PKG_NAME"),


### PR DESCRIPTION
## 概要

- `gethostname` クレートを `otel` feature に追加し、`service.instance.id` をホスト名で設定
- `TraceContextPropagator` と `global::set_tracer_provider()` をプロバイダー初期化時にグローバル登録
- `fetch_url` に `#[cfg_attr(feature = "otel", tracing::instrument(...))]` を付与して HTTP クライアントスパンを計装
- OTel / `process-metrics` feature フラグの詳細をスキルファイルに反映
- `.devcontainer` の 2 つのスクリプトに `gh-sync:keep` マーカーブロックを追加

## コミット構成

| # | type | 内容 |
|---|------|------|
| 1 | feat(otel) | gethostname で service.instance.id を設定、TraceContextPropagator 登録、fetch_url に instrument 付与 |
| 2 | docs(project-conventions) | otel / process-metrics feature フラグのドキュメントを更新 |
| 3 | chore(devcontainer) | initializeCommand.sh / postStartCommand.sh に gh-sync:keep マーカーを追加 |

## テスト計画

- [ ] `mise run test` — 全テスト (29 unit + 12 integration) が通ること
- [ ] `mise run pre-commit` — fmt / clippy / ast-grep / lint:gh が全てパスすること
- [ ] `mise run build:release` — リリースビルドが成功すること
- [ ] CI の全ジョブがグリーンになること