### PR TITLE
feat(otel): add service.instance.id and TraceContextPropagator

### DIFF
--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -41,6 +41,8 @@ run = "cargo test --doc"
 ["test:trace"]
 description = "Run tests against a fresh OpenObserve instance (restarts O2 for clean traces)"
 run = """
+#!/usr/bin/env bash
+set -euo pipefail
 mise run o2:stop
 mise run o2
 echo 'OpenObserve restarted with clean state'
@@ -55,6 +57,8 @@ cargo test --all-targets
 description = "Generate LCOV coverage report and verify thresholds"
 env = { OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:19999" }
 run = """
+#!/usr/bin/env bash
+set -euo pipefail
 rustup component add llvm-tools-preview --toolchain nightly-2026-01-15
 
 cargo +nightly-2026-01-15 llvm-cov --all-features --fail-under-lines 90
@@ -65,6 +69,8 @@ cargo +nightly-2026-01-15 llvm-cov --all-features --lcov --output-path target/lc
 description = "Generate HTML coverage report and open"
 env = { OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:19999" }
 run = """
+#!/usr/bin/env bash
+set -euo pipefail
 rustup component add llvm-tools-preview --toolchain nightly-2026-01-15
 
 cargo +nightly-2026-01-15 llvm-cov --all-features --html --open
@@ -73,6 +79,8 @@ cargo +nightly-2026-01-15 llvm-cov --all-features --html --open
 [fmt]
 description = "Run all formatters"
 run = """
+#!/usr/bin/env bash
+set -euo pipefail
 cargo fmt
 dprint fmt
 """
@@ -80,6 +88,8 @@ dprint fmt
 ["fmt:check"]
 description = "Check all formatting"
 run = """
+#!/usr/bin/env bash
+set -euo pipefail
 cargo fmt -- --check
 dprint check
 """
@@ -103,6 +113,8 @@ depends = ["fmt:check", "clippy:strict", "ast-grep"]
 ["lint:gh"]
 description = "Lint GitHub Actions workflows"
 run = """
+#!/usr/bin/env bash
+set -euo pipefail
 actionlint
 ghalint run
 ghalint run-action
@@ -140,6 +152,7 @@ run = "cargo sweep --time 1"
 ["claudecode:install"]
 description = "Install Claude Code to ~/.local/bin via official installer"
 run = """
+#!/usr/bin/env bash
 set -euo pipefail
 if command -v claude > /dev/null 2>&1; then
   echo "Claude Code already installed: $(claude --version)"
@@ -155,6 +168,7 @@ curl -sfSL --retry 3 --retry-delay 2 --retry-connrefused https://claude.ai/insta
 ["badges:init"]
 description = "Initialize orphan badges branch with empty placeholder files"
 run = """
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Idempotent: skip if remote badges branch already exists
@@ -185,6 +199,7 @@ echo 'badges branch initialized. Badges will be generated on first CI run.'
 ["o2:install"]
 description = "Install OpenObserve Enterprise to ~/.local/bin"
 run = """
+#!/usr/bin/env bash
 set -euo pipefail
 
 install_dir="${HOME}/.local/bin"
@@ -231,6 +246,8 @@ echo "OpenObserve ${version} installed to ${target}"
 description = "Start OpenObserve (OTLP HTTP via :5080, UI :5080)"
 env = { OTEL_EXPORTER_OTLP_ENDPOINT = "" }
 run = """
+#!/usr/bin/env bash
+set -euo pipefail
 if ! command -v openobserve > /dev/null 2>&1; then
   echo 'Error: openobserve not found. Run "mise run o2:install" first.' >&2
   exit 1
@@ -261,6 +278,7 @@ pkill -x openobserve 2>/dev/null && while pgrep -x openobserve > /dev/null; do s
 ["codeql:install"]
 description = "Create CodeQL database and download query packs"
 run = """
+#!/usr/bin/env bash
 set -euo pipefail
 
 db_dir="target/codeql-db"
@@ -292,6 +310,7 @@ echo '    Run analysis: mise run codeql'
 [codeql]
 description = "Run CodeQL analysis (SARIF output)"
 run = """
+#!/usr/bin/env bash
 set -euo pipefail
 
 db_dir="target/codeql-db"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,12 +430,12 @@ dependencies = [
 
 [[package]]
 name = "gethostname"
-version = "0.5.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3655aa6818d65bc620d6911f05aa7b6aeb596291e1e9f79e52df85583d1e30"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix 0.38.44",
- "windows-targets 0.52.6",
+ "rustix",
+ "windows-link",
 ]
 
 [[package]]
@@ -824,12 +824,6 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1339,19 +1333,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1359,7 +1340,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -1659,7 +1640,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ sysinfo = { version = "0.38", default-features = false, features = ["system"] }
 opentelemetry-semantic-conventions = { version = "0.31", default-features = false, features = ["semconv_experimental"] }
 
 ## Hostname (optional, behind `otel` feature)
-gethostname = "0.5"
+gethostname = "1.1.0"
 
 ## OpenTelemetry (optional, behind `otel` feature)
 opentelemetry = { version = "0.31", default-features = false, features = ["trace", "metrics", "logs"] }


### PR DESCRIPTION
## 概要

- `gethostname` を使って `service.instance.id` を OTel リソースに設定し、ホスト名でサービスインスタンスを一意に識別できるようにした
- `TraceContextPropagator` を追加して W3C Trace Context 形式でのコンテキスト伝播に対応した
- `gethostname` を 0.5 から 1.1.0 へアップグレードし、依存ツリーを簡素化した
- mise の全マルチラインシェルタスクに `#!/usr/bin/env bash` シェバンと `set -euo pipefail` を統一的に追加した
- `rustls-webpki` を 0.103.13 へアップグレードして RUSTSEC-2026-0104 に対応した
- devcontainer のシェルスクリプトに `gh-sync:keep` マーカーを追加した

## コミット一覧

- `feat(otel)`: add gethostname-based service.instance.id and TraceContextPropagator
- `docs(project-conventions)`: update OTel feature flag documentation
- `chore(devcontainer)`: add gh-sync:keep markers to shell scripts
- `fix(deps)`: upgrade rustls-webpki to 0.103.13 (RUSTSEC-2026-0104)
- `chore(mise)`: add bash shebangs to all multi-line tasks
- `fix(deps)`: upgrade gethostname to 1.1.0

## テスト計画

- [ ] `mise run test` — 全ユニット・統合テストがパスすること
- [ ] `mise run pre-commit` — フォーマット・clippy・ast-grep・lint:gh がパスすること
- [ ] `mise run build:release` — リリースビルドが成功すること
- [ ] OTel 有効時にホスト名が `service.instance.id` として OpenObserve に記録されること