### PR TITLE
chore(mise): refactor badges:init to use git worktree add --orphan

### DIFF
--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -166,34 +166,29 @@ curl -sfSL --retry 3 --retry-delay 2 --retry-connrefused https://claude.ai/insta
 """
 
 ["badges:init"]
-description = "Initialize orphan badges branch with empty placeholder files"
+description = "Initialize badges branch with placeholder SVGs for octocov"
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Idempotent: skip if remote badges branch already exists
-if git ls-remote --heads origin badges | grep -q badges; then
-  echo 'Remote badges branch already exists — skipping.'
-  exit 0
+if git show-ref --verify --quiet refs/heads/badges; then
+  echo "Error: 'badges' branch already exists. Delete it first: git branch -D badges" >&2
+  exit 1
 fi
 
-# Create orphan branch in a temporary worktree
-tmp="$(mktemp -d)"
-trap 'git worktree remove --force "${tmp}" 2>/dev/null; rm -rf "${tmp}"' EXIT
-git worktree add --detach "${tmp}"
-git -C "${tmp}" config --local --unset core.hookspath 2>/dev/null || true
-cd "${tmp}"
-git checkout --orphan badges
-git rm -rf . > /dev/null 2>&1
-git clean -fd > /dev/null 2>&1
+tmpdir=$(mktemp -d)
+trap 'git worktree remove --force "$tmpdir" 2>/dev/null || true; rm -rf "$tmpdir"' EXIT
 
-# Empty placeholders — octocov overwrites these on first CI run
-touch coverage.svg time.svg
-git add coverage.svg time.svg
-git commit -m "chore: initialize badges branch"
-git push origin badges
+git worktree add --orphan -b badges "$tmpdir"
 
-echo 'badges branch initialized. Badges will be generated on first CI run.'
+_svg='<svg xmlns="http://www.w3.org/2000/svg"/>'
+printf '%s' "$_svg" > "$tmpdir/coverage.svg"
+printf '%s' "$_svg" > "$tmpdir/time.svg"
+
+git -C "$tmpdir" add coverage.svg time.svg
+git -C "$tmpdir" commit -m "chore: initialize badges branch [skip ci]"
+
+echo "Badges branch initialized. Run: git push origin badges"
 """
 
 ["o2:install"]


### PR DESCRIPTION
## 概要

- `git ls-remote` (ネットワーク) → `git show-ref` (ローカル) でのブランチ存在チェックに変更し、不要なリモートアクセスを排除
- 複数ステップの orphan ブランチ作成を `git worktree add --orphan -b badges` に統合し、コードを簡素化
- `touch` (空ファイル) → 最小限の有効 SVG コンテンツ (`<svg xmlns="http://www.w3.org/2000/svg"/>`) に変更し、octocov 互換性を向上
- 自動 `git push` を削除し、ユーザーへの手動 push 指示 (`Run: git push origin badges`) に変更して誤操作を防止
- `printf` リテラルを変数 `_svg` に抽出し、重複を排除

## テスト計画

- [ ] pre-commit (fmt:check, clippy:strict, ast-grep, lint:gh) の通過確認
- [ ] CI チェックの通過確認