### PR TITLE
fix(ci): push coverage badges via GitHub Git Data API

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -215,7 +215,7 @@ jobs:
     timeout-minutes: ${{ fromJSON(needs.setup.outputs.timeout_minutes) }}
     permissions:
       actions: read #         For octocov to retrieve previous reports from artifacts
-      contents: write #       For octocov to push badges to repository
+      contents: write #       For pushing coverage badges to the badges branch
       pull-requests: write #  For octocov to comment on pull requests
 
     steps:
@@ -282,3 +282,54 @@ jobs:
         uses: k1LoW/octocov-action@73d561f65d59e66899ed5c87e4621a913b5d5c20 # v1.5.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push coverage badges
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          [[ -f coverage.svg && -f time.svg ]] || { echo "Badge files not found, skipping"; exit 0; }
+
+          # Create blobs via stdin (avoids shell argument size limits)
+          coverage_blob=$(base64 -w0 coverage.svg \
+            | jq -Rsc '{"encoding":"base64","content":.}' \
+            | gh api "repos/${GITHUB_REPOSITORY}/git/blobs" --method POST --input - --jq '.sha')
+          time_blob=$(base64 -w0 time.svg \
+            | jq -Rsc '{"encoding":"base64","content":.}' \
+            | gh api "repos/${GITHUB_REPOSITORY}/git/blobs" --method POST --input - --jq '.sha')
+
+          # Get current badges branch state
+          head_sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/badges" --jq '.object.sha')
+          tree_sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/commits/${head_sha}" --jq '.tree.sha')
+
+          # Skip if content unchanged (compare blob SHAs)
+          coverage_existing=$(gh api "repos/${GITHUB_REPOSITORY}/git/trees/${tree_sha}" \
+            --jq '.tree[] | select(.path == "coverage.svg") | .sha')
+          time_existing=$(gh api "repos/${GITHUB_REPOSITORY}/git/trees/${tree_sha}" \
+            --jq '.tree[] | select(.path == "time.svg") | .sha')
+          if [[ "$coverage_blob" == "$coverage_existing" && "$time_blob" == "$time_existing" ]]; then
+            echo "No badge changes"
+            exit 0
+          fi
+
+          # Build new tree and commit via API (API commits are signed by GitHub)
+          tree_json=$(printf \
+            '[{"path":"coverage.svg","mode":"100644","type":"blob","sha":"%s"},{"path":"time.svg","mode":"100644","type":"blob","sha":"%s"}]' \
+            "$coverage_blob" "$time_blob")
+          new_tree=$(gh api "repos/${GITHUB_REPOSITORY}/git/trees" \
+            --method POST --field base_tree="${tree_sha}" \
+            --field tree="${tree_json}" --jq '.sha')
+
+          parents_json=$(printf '["%s"]' "$head_sha")
+          new_commit=$(gh api "repos/${GITHUB_REPOSITORY}/git/commits" \
+            --method POST \
+            --field message="Update coverage badges [skip ci]" \
+            --field tree="${new_tree}" \
+            --field parents="${parents_json}" --jq '.sha')
+
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/badges" \
+            --method PATCH --field sha="${new_commit}"
+          echo "Coverage badges updated"

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -21,11 +21,6 @@ coverage:
 diff:
   datastores:
     - artifact://${GITHUB_REPOSITORY}
-push:
-  if: is_default_branch
-  datastores:
-    - github://${GITHUB_REPOSITORY}@badges
-  message: "Update coverage badges [skip ci]"
 report:
   if: is_default_branch
   datastores:


### PR DESCRIPTION
## 概要

- `octocov` の組み込み push が `.gitignore` により `coverage.svg` / `time.svg` を認識できず、バッジが更新されない問題を修正
- `.octocov.yml` の `push` セクションを削除し、CI の専用ステップに置き換え
- GitHub Git Data API (blob → tree → commit → ref) で 1 つのアトミックコミットとして `badges` ブランチを更新
- blob は stdin パイプで作成 (シェル引数サイズ制限を回避)
- blob SHA が変化していない場合はスキップ
- API 経由のコミットは GitHub が自動署名

Ported from: naa0yama/boilerplate-python#765

## Root cause

`octocov` の `PushUsingLocalGit` は `go-git` の `Worktree.Status()` でファイルを検出するが、`.gitignore` に列挙されたファイルは git status に出てこないためステージ不可。

## Test plan

- [ ] `main` へのマージ後に CI が実行され、`badges` ブランチに `coverage.svg` / `time.svg` が更新されることを確認
- [ ] 2 回目の実行 (badge 内容が同じ) で "No badge changes" と表示されスキップされることを確認