### PR TITLE
fix(ci): use --input - for git tree and commit API calls

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -315,20 +315,16 @@ jobs:
             exit 0
           fi
 
-          # Build new tree and commit via API (API commits are signed by GitHub)
-          tree_json=$(printf \
-            '[{"path":"coverage.svg","mode":"100644","type":"blob","sha":"%s"},{"path":"time.svg","mode":"100644","type":"blob","sha":"%s"}]' \
-            "$coverage_blob" "$time_blob")
-          new_tree=$(gh api "repos/${GITHUB_REPOSITORY}/git/trees" \
-            --method POST --field base_tree="${tree_sha}" \
-            --field tree="${tree_json}" --jq '.sha')
+          # Use --input - to pass complete JSON body, avoiding --field parsing issues
+          new_tree=$(printf \
+            '{"base_tree":"%s","tree":[{"path":"coverage.svg","mode":"100644","type":"blob","sha":"%s"},{"path":"time.svg","mode":"100644","type":"blob","sha":"%s"}]}' \
+            "$tree_sha" "$coverage_blob" "$time_blob" \
+            | gh api "repos/${GITHUB_REPOSITORY}/git/trees" --method POST --input - --jq '.sha')
 
-          parents_json=$(printf '["%s"]' "$head_sha")
-          new_commit=$(gh api "repos/${GITHUB_REPOSITORY}/git/commits" \
-            --method POST \
-            --field message="Update coverage badges [skip ci]" \
-            --field tree="${new_tree}" \
-            --field parents="${parents_json}" --jq '.sha')
+          new_commit=$(printf \
+            '{"message":"Update coverage badges [skip ci]","tree":"%s","parents":["%s"]}' \
+            "$new_tree" "$head_sha" \
+            | gh api "repos/${GITHUB_REPOSITORY}/git/commits" --method POST --input - --jq '.sha')
 
           gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/badges" \
             --method PATCH --field sha="${new_commit}"


### PR DESCRIPTION
## 概要

- PR #412 の `--field tree=[...]` が `gh api` に文字列としてラップされ、GitHub Git Trees API が HTTP 422 を返す問題を修正
- tree 作成・commit 作成の両 API 呼び出しを `--input -` (stdin 経由の完全 JSON ボディ) に変更
- `tree_json` / `parents_json` の中間変数を削除

Ported from: naa0yama/boilerplate-python#766

## Root cause

`gh api --field key=[...]` は値が `[` で始まっても JSON 配列として渡されず文字列にラップされるため、GitHub Git Trees API が `Invalid tree info (HTTP 422)` を返していた。

## Test plan

- [ ] `main` へのマージ後に CI が実行され、`badges` ブランチに `coverage.svg` / `time.svg` が更新されることを確認
- [ ] 2 回目の実行で "No badge changes" と表示されスキップされることを確認