### PR TITLE
feat(devcontainer): use XDG_RUNTIME_DIR for SSH and GPG socket forwarding

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,6 +20,7 @@
 		"type=bind,source=${localEnv:HOME}/.claude,target=/home/cuser/.claude",
 		"type=bind,source=${localEnv:HOME}/.claude.json,target=/home/cuser/.claude.json",
 		// Git
+		"type=bind,source=${localEnv:HOME}/.gitconfig,target=/home/cuser/.gitconfig",
 		"type=bind,source=${localEnv:HOME}/.gitconfig.d,target=/home/cuser/.gitconfig.d",
 		// GitHub
 		"type=bind,source=${localEnv:HOME}/.config/gh,target=/home/cuser/.config/gh",

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -3,10 +3,14 @@ set -euo pipefail
 
 echo "Validating mounted files and directories..."
 
-# List of expected mounted files and directories (optional)
+# All bind mount targets defined in devcontainer.json (volumes excluded).
+# Each entry must be pre-created in Dockerfile to avoid Docker creating them as root.
 EXPECTED_MOUNTS=(
-	"$HOME/.claude.json"
 	"$HOME/.claude/"
+	"$HOME/.claude.json"
+	"$HOME/.gitconfig"
+	"$HOME/.gitconfig.d/"
+	"$HOME/.config/gh/"
 )
 
 validation_failed=false
@@ -47,11 +51,29 @@ fi
 
 if [ "$installed_version" != "$MISE_PINNED_VERSION" ]; then
 	echo "Installing mise v${MISE_PINNED_VERSION} (installed: ${installed_version:-none})..."
-	MISE_VERSION="v${MISE_PINNED_VERSION}" \
-		curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused \
-		https://mise.jdx.dev/install.sh | sh
+	curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused \
+		https://mise.jdx.dev/install.sh | MISE_VERSION="v${MISE_PINNED_VERSION}" bash
 fi
 mise --version
+
+# GPG homedir: ensure 700 permissions (GPG refuses to run otherwise)
+_gpg_home="${GNUPGHOME:-$HOME/.gnupg}"
+mkdir -p "${_gpg_home}"
+chmod 700 "${_gpg_home}"
+
+# GPG: suppress local agent auto-start only when the host socket is forwarded.
+# Without this guard, VS Code (which provides its own GPG forwarding) would have
+# gpg.conf polluted with no-autostart, breaking all GPG operations.
+_gpg_rtdir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+if [ -S "${_gpg_rtdir}/gnupg/S.gpg-agent" ]; then
+	_gpg_conf="${_gpg_home}/gpg.conf"
+	if [ ! -f "${_gpg_conf}" ] || ! grep -q '^no-autostart' "${_gpg_conf}"; then
+		echo "no-autostart" >> "${_gpg_conf}"
+		echo "GPG: added 'no-autostart' to ${_gpg_conf}"
+	fi
+	unset _gpg_conf
+fi
+unset _gpg_rtdir _gpg_home
 
 chmod +x .githooks/*
 git config --local --unset core.hookspath || true

--- a/.devcontainer/traefik.sh
+++ b/.devcontainer/traefik.sh
@@ -45,6 +45,12 @@ _branch() {
 		| cut -c1-63
 }
 
+# Read the container user's UID from devcontainer.json build args
+_container_uid() {
+	_jsonc "$(_workspace)/.devcontainer/devcontainer.json" \
+		| jq -r '.build.args.USER_UID // "1000"'
+}
+
 # Strip single-line comments (//) from JSONC before passing to jq
 _jsonc() {
 	sed -e '/^[[:space:]]*\/\//d' -e 's|[[:space:]]//[^"]*$||g' "${1}"
@@ -300,6 +306,7 @@ UNIT
 
 cmd_up() {
 	local workspace project branch ports run_args tmpfile result container_id
+	local _cuid _gpg_sock _gpg_home
 
 	_host_check
 
@@ -324,12 +331,46 @@ cmd_up() {
 	fi
 
 	run_args='["--label=devcontainer.project='"${project}"'"'
+	run_args="${run_args},\"--env=COLORTERM=${COLORTERM:-}\""
+	run_args="${run_args},\"--env=TERM=${TERM:-xterm-256color}\""
 	run_args="${run_args},\"--env=TRAEFIK_MANAGED=1\""
 	run_args="${run_args},\"--env=TRAEFIK_PROJECT=${project}\""
 	run_args="${run_args},\"--env=TRAEFIK_DYNAMIC_DIR=${TRAEFIK_DYNAMIC_CONTAINER_PATH}\""
 	run_args="${run_args},\"--env=TRAEFIK_API_BASE=http://host.docker.internal:${TRAEFIK_PORT_DASHBOARD}\""
 	run_args="${run_args},\"--mount=type=bind,source=${TRAEFIK_DYNAMIC_DIR},target=${TRAEFIK_DYNAMIC_CONTAINER_PATH}\""
-	run_args="${run_args},\"--add-host=host.docker.internal:host-gateway\"]"
+	run_args="${run_args},\"--add-host=host.docker.internal:host-gateway\""
+
+	# Resolve container UID once for XDG runtime dir paths
+	_cuid="$(_container_uid)"
+
+	# SSH agent forwarding
+	if [ -n "${SSH_AUTH_SOCK:-}" ] && [ -S "${SSH_AUTH_SOCK}" ]; then
+		run_args="${run_args},\"--mount=type=bind,source=${SSH_AUTH_SOCK},target=/run/user/${_cuid}/ssh-agent.sock\""
+		run_args="${run_args},\"--env=SSH_AUTH_SOCK=/run/user/${_cuid}/ssh-agent.sock\""
+	else
+		echo "Note: SSH_AUTH_SOCK not available; skipping SSH agent forwarding." >&2
+	fi
+
+	# GPG agent socket forwarding + public keyring
+	_gpg_sock="$(gpgconf --list-dirs agent-socket 2>/dev/null || true)"
+	if [ -n "${_gpg_sock}" ] && [ -S "${_gpg_sock}" ]; then
+		run_args="${run_args},\"--mount=type=bind,source=${_gpg_sock},target=/run/user/${_cuid}/gnupg/S.gpg-agent\""
+	else
+		echo "Note: GPG agent socket not available; skipping GPG forwarding." >&2
+	fi
+	# S.gpg-agent.extra is intentionally NOT forwarded: gpg(1) connects to S.gpg-agent
+	# only. The extra socket is for restricted remote clients (e.g., SSH RemoteForward);
+	# nothing inside this container needs it.
+	# GPG public keyring: needed so gpg knows which key to request from the agent
+	_gpg_home="${GNUPGHOME:-$HOME/.gnupg}"
+	if [ -f "${_gpg_home}/pubring.kbx" ]; then
+		run_args="${run_args},\"--mount=type=bind,source=${_gpg_home}/pubring.kbx,target=/home/cuser/.gnupg/pubring.kbx,readonly\""
+	fi
+	# trustdb.gpg is intentionally NOT mounted: GPG writes maintenance updates to it,
+	# and a readonly mount causes write warnings on every invocation. GPG auto-creates
+	# a fresh trustdb inside the container; trust is not needed for signing.
+
+	run_args="${run_args}]"
 
 	# --override-config replaces (not merges) devcontainer.json, so we must
 	# merge our runArgs into the full base config before passing it.

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,12 @@ RUN echo "**** Add sudo user ****" && \
 	set -euxo pipefail && \
 	echo -e "${USER_NAME}\tALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${USER_NAME}"
 
+RUN echo "**** Create XDG runtime dir ****" && \
+	set -euxo pipefail && \
+	mkdir -p /run/user/${USER_UID}/gnupg && \
+	chown -R ${USER_NAME}:${USER_NAME} /run/user/${USER_UID} && \
+	chmod 700 /run/user/${USER_UID} /run/user/${USER_UID}/gnupg
+
 RUN echo "**** Install mold ****" && \
 	set -euxo pipefail && \
 	_release_data="$(curl ${CURL_OPTS} -H 'User-Agent: builder/1.0' \
@@ -138,13 +144,22 @@ ENV CARGO_HOME=/home/${USER_NAME}/.cargo
 RUN echo "**** Directory Create ****" && \
 	set -euxo pipefail && \
 	mkdir -p \
+	~/.claude \
 	~/.config \
+	~/.config/gh \
 	~/.config/mise \
+	~/.gitconfig.d \
+	~/.gnupg \
 	~/.local \
 	~/.local/bin \
 	~/.local/share \
 	~/.local/share/claude \
-	~/.local/share/mise
+	~/.local/share/mise && \
+	chmod 700 ~/.gnupg && \
+	touch \
+	~/.claude.json \
+	~/.gitconfig \
+	~/.gnupg/pubring.kbx
 
 RUN echo "**** Create ${CARGO_HOME} ****" && \
 	set -euxo pipefail && \
@@ -182,6 +197,8 @@ case ":$PATH:" in
 	*:"$HOME/.local/bin":*) ;;
 	*) export PATH="$HOME/.local/bin:$PATH" ;;
 esac
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+export GPG_TTY=$(tty 2>/dev/null || true)
 alias cc="claude --dangerously-skip-permissions"
 
 _DOC_

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ mise use --global node@lts
 mise use --global devcontainer-cli@0.86.0
 ```
 
+`dev:up` 実行時に、ホストで `ssh-agent` と `gpg-agent` が起動していれば
+SSH エージェント転送と GPG 署名がコンテナ内で自動的に有効になります。
+未起動の場合は起動時に警告が出力されますが、開発は続行できます。
+
 ### 初回セットアップ (WSL2 ホストで1回だけ実行)
 
 前提条件のインストール後、以下を実行します。


### PR DESCRIPTION
## Summary

- SSH agent socket を `/run/user/<uid>/ssh-agent.sock` に移動してセキュリティを強化
- GPG agent socket を `/run/user/<uid>/gnupg/S.gpg-agent` に移動
- Dockerfile で `/run/user/<uid>/gnupg` を root 権限で事前作成し、`chmod 700` を適用
- `.bashrc` に `XDG_RUNTIME_DIR` を export して GPG がソケットを自動検出できるように設定
- `_container_uid()` ヘルパーを追加して `devcontainer.json` から `USER_UID` を動的取得
- `~/.gitconfig` バインドマウントを `devcontainer.json` に追加
- マウント検証リストに `.gitconfig`、`.gitconfig.d`、`.config/gh` を追加
- `| sh` を `| bash` に統一
- README に SSH/GPG 転送の説明を追加

Backport of naa0yama/boilerplate-python#777

## Test plan

- [ ] `mise run dev:up` でコンテナを起動し、SSH agent が `/run/user/1100/ssh-agent.sock` にマウントされることを確認
- [ ] コンテナ内で `echo $XDG_RUNTIME_DIR` が `/run/user/1100` を返すことを確認
- [ ] コンテナ内で `gpg --list-keys` が正常動作することを確認
- [ ] コンテナ内で git commit に GPG 署名が付くことを確認
- [ ] `stat -c '%a' /run/user/1100/gnupg` が `700` を返すことを確認