### PR TITLE
fix(githooks): resolve repo name from remote URL in devcontainer

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -21,7 +21,7 @@ fi
 # Types match dot_gitconfig.d/message.txt
 commit_regex='^(feat|update|fix|style|refactor|docs|perf|test|build|ci|chore|remove|revert)(\([a-zA-Z0-9_\-]+\))?!?: .+$'
 
-if ! echo "$first_line" | grep -qE "$commit_regex"; then
+if ! grep -qE "$commit_regex" <<< "$first_line"; then
     echo "コミットメッセージが Conventional Commits 形式に準拠していません" >&2
     echo "" >&2
     echo "正しい形式:" >&2
@@ -51,15 +51,6 @@ if ! echo "$first_line" | grep -qE "$commit_regex"; then
     echo "現在のメッセージ:" >&2
     echo "  $first_line" >&2
     echo "" >&2
-    exit 1
-fi
-
-# Verify colon + space after type
-if ! echo "$first_line" | grep -qE '^[a-z]+(\([a-zA-Z0-9_\-]+\))?!?: .+$'; then
-    echo "typeの後には「: 」(コロン + 半角スペース)が必要です" >&2
-    echo "" >&2
-    echo "現在のメッセージ:" >&2
-    echo "  $first_line" >&2
     exit 1
 fi
 

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -10,7 +10,26 @@ if [ -z "${TMUX:-}" ]; then
     exit 0
 fi
 
-repo=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null) || exit 0
+# Resolve repo name: prefer remote URL (works in devcontainer where workspaceFolder is /app)
+_git_user=$(git config github.user 2>/dev/null || printf '')
+remote_url=$(git remote get-url origin 2>/dev/null || printf '')
+repo=""
+if [ -n "$remote_url" ]; then
+    owner_repo=$(printf '%s' "$remote_url" | sed -E 's#^.+[:/]([^/]+)/([^/]+)$#\1/\2#' | sed 's#\.git$##')
+    if [[ "$owner_repo" =~ ^[^/]+/[^/]+$ ]]; then
+        repo_owner="${owner_repo%%/*}"
+        repo_name="${owner_repo##*/}"
+        if [ -n "$_git_user" ] && [ "$repo_owner" = "$_git_user" ]; then
+            repo="$repo_name"
+        else
+            repo="$owner_repo"
+        fi
+    fi
+fi
+if [ -z "$repo" ]; then
+    repo=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null) || exit 0
+fi
+
 branch=$(git branch --show-current 2>/dev/null) || exit 0
 [ -n "$repo" ] && [ -n "$branch" ] || exit 0
 

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -6,16 +6,23 @@ if [ "${3:-0}" != "1" ]; then
     exit 0
 fi
 
+# TMUX check uses ${TMUX:-} (empty default) to avoid set -u unbound-variable error.
 if [ -z "${TMUX:-}" ]; then
     exit 0
 fi
 
-# Resolve repo name: prefer remote URL (works in devcontainer where workspaceFolder is /app)
+# Resolve repo name: prefer remote URL (works in devcontainer where workspaceFolder is /app).
+# Split into two sed pipes: BSD sed errors on -E + semicolon chaining (GNU-only).
 _git_user=$(git config github.user 2>/dev/null || printf '')
 remote_url=$(git remote get-url origin 2>/dev/null || printf '')
+# repo="" init + deferred [ -z "$repo" ] below is a unified fallback for two cases:
+# (1) no remote URL, (2) remote URL did not parse to a valid owner/repo.
+# Do not duplicate the basename fallback back into both if/else branches.
 repo=""
 if [ -n "$remote_url" ]; then
     owner_repo=$(printf '%s' "$remote_url" | sed -E 's#^.+[:/]([^/]+)/([^/]+)$#\1/\2#' | sed 's#\.git$##')
+    # Guard: sed passes the raw URL unchanged when the pattern does not match
+    # (non-GitHub host, local path, etc.), so validate before use.
     if [[ "$owner_repo" =~ ^[^/]+/[^/]+$ ]]; then
         repo_owner="${owner_repo%%/*}"
         repo_name="${owner_repo##*/}"
@@ -26,6 +33,7 @@ if [ -n "$remote_url" ]; then
         fi
     fi
 fi
+# exit 0 (not || true): no usable repo name means nothing to set; skip silently.
 if [ -z "$repo" ]; then
     repo=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null) || exit 0
 fi
@@ -33,4 +41,5 @@ fi
 branch=$(git branch --show-current 2>/dev/null) || exit 0
 [ -n "$repo" ] && [ -n "$branch" ] || exit 0
 
+# || true: set-option -p targets the current pane and may fail if unsupported; best-effort.
 tmux set-option -p @pane-name "${repo}:${branch}" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- **devcontainer 内 `app:main` バグ修正**: `workspaceFolder` が `/app` にマウントされる環境で `basename` が `app` を返す問題を修正。`git remote get-url origin` を最優先でリポジトリ名取得に使用し、SSH/HTTPS 両形式に対応。`statusline-command.sh` と同一手法を採用
- **`commit-msg` デッドコード削除**: `commit_regex` がコロン+スペースを既に必須にしているため、2 番目の `grep` チェックは到達不能だった。削除
- **`commit-msg` herestring 統一**: `echo pipe` を `<<<` に変更し、Merge チェック (line 16) と一貫させる
- **`post-checkout` WHY コメント追記**: `set -u` 対策の `${TMUX:-}`、BSD sed 互換の 2 パイプ、フォールバック統合パターン、`|| exit 0` vs `|| true` の使い分けを説明
- **`sed` BSD/GNU 互換修正**: `sed -E '...; ...'` セミコロン連結 (GNU-only) を 2 パイプに変更

## Test plan

- [ ] devcontainer 内でブランチチェックアウト後、tmux ペイン名が `boilerplate-rust:main` になることを確認
- [ ] ホスト環境で既存動作が変わらないことを確認
- [ ] `git config github.user` 未設定時に `owner/repo` 形式で表示されることを確認
- [ ] remote なし環境で `basename` フォールバックが動作することを確認
- [ ] Conventional Commits 形式のコミットメッセージが引き続き正常に検証されることを確認