### PR TITLE
chore(graft): add .githooks/post-checkout to sync manifest

### DIFF
--- a/.github/graft/config.yaml
+++ b/.github/graft/config.yaml
@@ -303,6 +303,8 @@ files:
   # .githooks
   - path: .githooks/commit-msg
     strategy: replace
+  - path: .githooks/post-checkout
+    strategy: replace
   - path: .githooks/pre-commit
     strategy: replace
   - path: .githooks/pre-push


### PR DESCRIPTION
## Summary

- `.github/graft/config.yaml` の `.githooks` セクションに `.githooks/post-checkout` を追加 (strategy: replace)
- 他の githooks エントリ (`commit-msg`, `pre-commit`, `pre-push`) と同様にアルファベット順で配置
- テンプレートリポジトリからの同期対象に含める

## Test plan

- [ ] graft config の YAML 構文が正しいことを確認
- [ ] `.githooks/post-checkout` が boilerplate-rust テンプレートから正しく同期されることを確認