### PR TITLE
refactor(devcontainer): simplify shell scripts and fix infra config

### DIFF
--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -73,6 +73,7 @@ fi
 unset _gpg_rtdir _gpg_home
 
 # SSH: populate known_hosts with github.com host keys inside the container
+# Idempotent: ~/.ssh may not exist if the host bind-mount was not set up yet.
 mkdir -p ~/.ssh && chmod 700 ~/.ssh
 ssh-keyscan -H github.com > ~/.ssh/known_hosts 2>/dev/null
 chmod 600 ~/.ssh/known_hosts

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -6,7 +6,7 @@ if [ "${3:-0}" != "1" ]; then
     exit 0
 fi
 
-# TMUX check uses ${TMUX:-} (empty default) to avoid set -u unbound-variable error.
+# Skip if not inside a tmux session; ${TMUX:-} avoids set -u error when TMUX is unset.
 if [ -z "${TMUX:-}" ]; then
     exit 0
 fi
@@ -24,10 +24,8 @@ if [ -n "$remote_url" ]; then
     # Guard: sed passes the raw URL unchanged when the pattern does not match
     # (non-GitHub host, local path, etc.), so validate before use.
     if [[ "$owner_repo" =~ ^[^/]+/[^/]+$ ]]; then
-        repo_owner="${owner_repo%%/*}"
-        repo_name="${owner_repo##*/}"
-        if [ -n "$_git_user" ] && [ "$repo_owner" = "$_git_user" ]; then
-            repo="$repo_name"
+        if [ -n "$_git_user" ] && [ "${owner_repo%%/*}" = "$_git_user" ]; then
+            repo="${owner_repo##*/}"
         else
             repo="$owner_repo"
         fi

--- a/.github/graft/config.yaml
+++ b/.github/graft/config.yaml
@@ -239,7 +239,6 @@ spec:
         - "k1low/gh-setup@*"
         - "k1low/octocov-action@*"
         - "mozilla-actions/sccache-action@*"
-        - "naa0yama/graft@*"
         - "songmu/tagpr@*"
         - "swatinem/rust-cache@*"
         - "taiki-e/install-action@*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -201,7 +201,7 @@ case ":$PATH:" in
 	*) export PATH="$HOME/.local/bin:$PATH" ;;
 esac
 export XDG_RUNTIME_DIR="/run/user/$(id -u)"
-export GPG_TTY=$(tty 2>/dev/null || true)
+export GPG_TTY="$(tty 2>/dev/null || true)"
 alias cc="claude --dangerously-skip-permissions"
 
 _DOC_


### PR DESCRIPTION
## Summary

- `.devcontainer/postStartCommand.sh`: `mkdir -p ~/.ssh && chmod 700 ~/.ssh` の冪等性を説明する WHY コメントを追加
- `.githooks/post-checkout`: TMUX チェックのコメントを `set -u` の理由を含む形に改善し、`repo_owner`/`repo_name` の中間変数をインライン化
- `.github/graft/config.yaml`: 自己参照アクション `naa0yama/graft@*` を `allowed_actions` から削除
- `Dockerfile`: `GPG_TTY` のコマンド置換をクォートで修正

## Test plan

- [ ] pre-commit が通ることを確認 (CI)
- [ ] devcontainer の再ビルドで postStartCommand.sh が正常に動作することを確認