### PR TITLE
build: add unexpected_cfgs lint to suppress coverage_nightly cfg warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,7 @@ cargo-common-metadata = "allow"
 warnings = "warn"
 missing_debug_implementations = "warn" #			Warning about unimplemented Debug trait
 missing_docs = "warn" #								Warning about insufficient documentation for pub items.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 
 # - -------------------------------------------------------------------------------------------------
 # - Profiles


### PR DESCRIPTION
## 概要

- `[workspace.lints.rust]` に `unexpected_cfgs` lint 設定を追加
- `cfg(coverage_nightly)` 使用時の "unexpected cfg condition" 警告を抑制

## テスト計画

- [x] `mise run pre-commit` パス
- [x] `mise run check` パス
- [x] GPG 署名済み