### PR TITLE
chore: update graft merge commit settings

### DIFF
--- a/.github/graft/config.yaml
+++ b/.github/graft/config.yaml
@@ -20,8 +20,8 @@ spec:
     auto_delete_head_branches: true
     squash_merge_commit_title: PR_TITLE
     squash_merge_commit_message: COMMIT_MESSAGES
-    merge_commit_title: PR_TITLE
-    merge_commit_message: BLANK
+    merge_commit_title: MERGE_MESSAGE
+    merge_commit_message: PR_TITLE
   release_immutability: true
   label_sync: mirror
   labels:


### PR DESCRIPTION
## 概要

- `merge_commit_title` を `PR_TITLE` から `MERGE_MESSAGE` に変更
- `merge_commit_message` を `BLANK` から `PR_TITLE` に変更

## テスト計画

- [ ] graft apply 後、GitHub リポジトリ設定で merge commit 設定値が反映されていることを確認