### PR TITLE
chore: bump Rust toolchain to 1.95.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ARG CURL_OPTS="-sfSL --retry 3 --retry-delay 2 --retry-connrefused"
 #- -------------------------------------------------------------------------------------------------
 #- Builder Base
 #-
-FROM --platform=$BUILDPLATFORM rust:1.94.1-trixie@sha256:652612f07bfbbdfa3af34761c1e435094c00dde4a98036132fca28c7bb2b165c AS builder-base
+FROM --platform=$BUILDPLATFORM rust:1.95.0-trixie@sha256:39d8cb39a54e7d1da665c4fabfdd265e532a5f836c11ab5aee27fd5c73891ce4 AS builder-base
 ARG CURL_OPTS \
 	DEBIAN_FRONTEND \
 	MOLD_VERSION \

--- a/crates/brust/src/telemetry/metrics/process.rs
+++ b/crates/brust/src/telemetry/metrics/process.rs
@@ -82,9 +82,7 @@ fn current_pid() -> Pid {
 /// multi-core hosts) into the 0..1 fraction required by
 /// `process.cpu.utilization`.
 fn logical_cpu_count() -> u32 {
-    let n = std::thread::available_parallelism()
-        .map(NonZeroUsize::get)
-        .unwrap_or(1);
+    let n = std::thread::available_parallelism().map_or(1, NonZeroUsize::get);
     u32::try_from(n).unwrap_or(1)
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.95.0"
 
 components = [
 	"cargo",


### PR DESCRIPTION
## Summary

- `rust-toolchain.toml` の channel を `1.94.1` → `1.95.0` に更新
- `Dockerfile` のベースイメージを `rust:1.95.0-trixie` に更新
- clippy 1.95.0 の新 lint 対応: `map().unwrap_or()` → `map_or()` (process.rs)

## 背景

PR #473 (sysinfo 0.38 → 0.39) が CI 失敗中。`sysinfo@0.39.x` は `rustc >= 1.95` を要求するが、現行 `1.94.1` ではコンパイル不可。この PR で toolchain を事前に上げておくことで、Renovate が自動で #473 をパスできるようにする。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `rust-toolchain.toml` | `channel = "1.94.1"` → `"1.95.0"` |
| `Dockerfile` | `rust:1.94.1-trixie` → `rust:1.95.0-trixie` |
| `crates/brust/src/telemetry/metrics/process.rs` | clippy 1.95.0 fix |

## CI 確認

- pre-commit: 全パス
- test: 41/41 全パス
- coverage: 全パス