### PR TITLE
fix(coverage): bump nightly toolchain to nightly-2026-03-15

### DIFF
--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -152,12 +152,12 @@ env = { OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:19999" }
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
-rustup component add llvm-tools-preview --toolchain nightly-2026-01-15
+rustup component add llvm-tools-preview --toolchain nightly-2026-03-15
 quiet=""; [[ "${CLAUDECODE:-}" == "1" ]] && quiet="--cargo-quiet --cargo-quiet --status-level fail"
 _cpus=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
 _threads=$(( _cpus * 7 / 10 < 1 ? 1 : _cpus * 7 / 10 ))
 if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then _threads="$_cpus"; fi
-cargo +nightly-2026-01-15 llvm-cov nextest --all-features --fail-under-lines 90 --lcov --output-path target/lcov.info --test-threads "$_threads" $quiet
+cargo +nightly-2026-03-15 llvm-cov nextest --all-features --fail-under-lines 90 --lcov --output-path target/lcov.info --test-threads "$_threads" $quiet
 """
 
 ["coverage:html"]
@@ -166,11 +166,11 @@ env = { OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:19999" }
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
-rustup component add llvm-tools-preview --toolchain nightly-2026-01-15
+rustup component add llvm-tools-preview --toolchain nightly-2026-03-15
 quiet=""; [[ "${CLAUDECODE:-}" == "1" ]] && quiet="--cargo-quiet --cargo-quiet --status-level fail"
 _cpus=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
 _threads=$(( _cpus * 7 / 10 < 1 ? 1 : _cpus * 7 / 10 ))
-cargo +nightly-2026-01-15 llvm-cov nextest --all-features --html --open --test-threads "$_threads" $quiet
+cargo +nightly-2026-03-15 llvm-cov nextest --all-features --html --open --test-threads "$_threads" $quiet
 """
 
 [deny]


### PR DESCRIPTION
## Summary

- `sysinfo 0.39.1` の MSRV は `rustc 1.95` だが、`tasks.toml` の coverage タスクは `nightly-2026-01-15` (`1.94.0-nightly`) にハードコードされており MSRV チェックで失敗していた
- `nightly-2026-03-15` (`1.96.0-nightly`) に更新することで PR #473 の CI が通るようになる

## Changes

- `.mise/tasks.toml`: `coverage` / `coverage:html` タスクの nightly を `nightly-2026-01-15` → `nightly-2026-03-15` に変更

## Test plan

- [ ] `mise run coverage` がローカルで通ることを確認済み (41 tests passed)
- [ ] CI の `rust-ci / test` (Generate coverage report) が通ること