### PR TITLE
feat(graft): add badges branch ruleset and testdata-policy ast-rules

### DIFF
--- a/.github/graft/config.yaml
+++ b/.github/graft/config.yaml
@@ -276,6 +276,15 @@ spec:
         creation: false
         required_linear_history: false
         required_signatures: true
+    - name: badges
+      target: branch
+      enforcement: active
+      conditions:
+        ref_name:
+          include:
+            - refs/heads/badges
+      rules:
+        deletion: true
 files:
   # .cargo
   - path: .cargo/config.toml
@@ -451,6 +460,14 @@ files:
   - path: ast-rules/no-hardcoded-credentials.yml
     strategy: replace
   - path: ast-rules/secure-random-required.yml
+    strategy: replace
+  - path: ast-rules/no-real-asn.yml
+    strategy: replace
+  - path: ast-rules/no-real-fqdn.yml
+    strategy: replace
+  - path: ast-rules/no-real-ipv4.yml
+    strategy: replace
+  - path: ast-rules/no-real-ipv6.yml
     strategy: replace
 
   # docs/o2-dashboards


### PR DESCRIPTION
## Summary

- `badges` ブランチに削除保護 ruleset を追加 (`deletion: true`)
  - UI からの誤削除を防止
  - GitHub Actions による coverage badge 更新 (ref PATCH) は引き続き動作
- `graft/config.yaml` の `files` に testdata-policy 関連 ast-grep ルール 4 本を追加
  - `ast-rules/no-real-asn.yml`
  - `ast-rules/no-real-fqdn.yml`
  - `ast-rules/no-real-ipv4.yml`
  - `ast-rules/no-real-ipv6.yml`

## Test plan

- [ ] graft apply 後に `badges` ブランチの Settings > Branches で削除ボタンが無効になることを確認
- [ ] main マージ後の CI で octocov が `badges` ブランチへ push できることを確認