### PR TITLE
chore(devcontainer): rename container user from cuser to user

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,19 +17,19 @@
 	// Add another local file mount.
 	"mounts": [
 		// Claude Code
-		"type=bind,source=${localEnv:HOME}/.claude,target=/home/cuser/.claude",
-		"type=bind,source=${localEnv:HOME}/.claude.json,target=/home/cuser/.claude.json",
+		"type=bind,source=${localEnv:HOME}/.claude,target=/home/user/.claude",
+		"type=bind,source=${localEnv:HOME}/.claude.json,target=/home/user/.claude.json",
 		// Git
-		"type=bind,source=${localEnv:HOME}/.gitconfig,target=/home/cuser/.gitconfig",
-		"type=bind,source=${localEnv:HOME}/.gitconfig.d,target=/home/cuser/.gitconfig.d",
+		"type=bind,source=${localEnv:HOME}/.gitconfig,target=/home/user/.gitconfig",
+		"type=bind,source=${localEnv:HOME}/.gitconfig.d,target=/home/user/.gitconfig.d",
 		// GitHub
-		"type=bind,source=${localEnv:HOME}/.config/gh,target=/home/cuser/.config/gh",
+		"type=bind,source=${localEnv:HOME}/.config/gh,target=/home/user/.config/gh",
 		// Cross-project shared: ~/.local/bin (mise/openobserve binary, claude symlink)
-		"type=volume,source=devcontainer-shared-local-bin,target=/home/cuser/.local/bin",
+		"type=volume,source=devcontainer-shared-local-bin,target=/home/user/.local/bin",
 		// Cross-project shared: mise managed tool installs
-		"type=volume,source=devcontainer-shared-mise,target=/home/cuser/.local/share/mise",
+		"type=volume,source=devcontainer-shared-mise,target=/home/user/.local/share/mise",
 		// Cross-project shared: claude binary versions (symlink target of ~/.local/bin/claude)
-		"type=volume,source=devcontainer-shared-claude,target=/home/cuser/.local/share/claude"
+		"type=volume,source=devcontainer-shared-claude,target=/home/user/.local/share/claude"
 	],
 	"customizations": {
 		"vscode": {
@@ -49,7 +49,7 @@
 			],
 			"settings": {
 				"window.title": "${localWorkspaceFolderBasename}${separator}${dirty}${activeEditorShort}${separator}${rootName}${separator}${profileName}${separator}${appName}",
-				"dprint.path": "/home/cuser/.local/share/mise/shims/dprint",
+				"dprint.path": "/home/user/.local/share/mise/shims/dprint",
 				"remote.autoForwardPorts": true,
 				"remote.autoForwardPortsSource": "process"
 			}
@@ -68,7 +68,7 @@
 		"MISE_GITHUB_TOKEN": "${localEnv:MISE_GITHUB_TOKEN}"
 	},
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	"remoteUser": "cuser",
+	"remoteUser": "user",
 	"workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind,consistency=delegated",
 	"workspaceFolder": "/app"
 }

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -32,14 +32,26 @@ echo "Badges branch initialized. Run: git push origin badges"
 """
 
 ["check:no-plans"]
-description = "Reject .claude/artifacts/*.md files"
+description = "Reject unabsorbed .claude/artifacts/*.md files"
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
 
-if find .claude/artifacts -name '*.md' -print -quit 2>/dev/null | grep -q .; then
-  echo 'Error: .claude/artifacts/ contains unabsorbed .md files.' >&2
-  echo 'Absorb design decisions into docs/specs/, then delete the files.' >&2
+rejected=""
+while IFS= read -r f; do
+  dir=$(dirname "$f")
+  plan="$dir/PLAN.md"
+  # task dir with an active PLAN.md → in progress, skip entire dir
+  if [[ -f "$plan" ]] && head -5 "$plan" | grep -q 'status: active'; then
+    continue
+  fi
+  rejected="${rejected}  ${f}"$'\n'
+done < <(find .claude/artifacts -name '*.md' 2>/dev/null)
+
+if [ -n "$rejected" ]; then
+  echo 'Error: .claude/artifacts/ contains unabsorbed .md files:' >&2
+  printf '%s' "$rejected" >&2
+  echo 'Absorb design decisions into docs/specs/, then delete.' >&2
   exit 1
 fi
 """

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,28 @@ Conventional Commits: `<type>: <description>` or `<type>(<scope>): <description>
 
 Allowed types: feat, update, fix, style, refactor, docs, perf, test, build, ci, chore, remove, revert
 
+## Artifacts Convention
+
+When using `subagent-driven-development`, save progress to:
+
+```
+.claude/artifacts/
+  plans/        # session feature plans (ephemeral)
+  <task-slug>/  # subagent work (PLAN.md, IMPL.md, REVIEW.md)
+```
+
+All files are ephemeral. Absorb design decisions into `docs/specs/`,
+then delete the artifacts.
+
+`check:no-plans` (runs in `pre-commit`) blocks commit when unabsorbed `.md`
+files exist under `.claude/artifacts/` — except task dirs where `PLAN.md`
+has `status: active` (in-progress tasks are exempt from blocking).
+
+Each task's `PLAN.md` frontmatter (required):
+
+- `status`: `active` (in-progress) or `completed` (code review passed)
+- `source_spec`: path to the originating plan file in `plans/`
+
 ## Workflow
 
 1. Write tests (for new features / bug fixes)

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #-
 ARG DEBIAN_FRONTEND=noninteractive \
 	TZ=${TZ:-Asia/Tokyo} \
-	USER_NAME=cuser \
+	USER_NAME=user \
 	USER_UID=${USER_UID:-60001} \
 	USER_GID=${USER_GID:-${USER_UID}}
 
@@ -202,7 +202,7 @@ case ":$PATH:" in
 esac
 export XDG_RUNTIME_DIR="/run/user/$(id -u)"
 export GPG_TTY="$(tty 2>/dev/null || true)"
-alias cc="claude --dangerously-skip-permissions"
+alias cc="claude"
 
 _DOC_
 EOF


### PR DESCRIPTION
## 背景

Claude marketplace の plugin は設定ファイルに fullpath を書き込む際、
WSL2 ホストのユーザーホーム `/home/user/.claude` の形式で記載する。
devcontainer のユーザー名が `cuser` だとパスが一致せず plugin が使えない
状態だった。Rust LSP など有用な plugin のために devcontainer 側を統一する。

## 変更内容

- `Dockerfile`, `.devcontainer/devcontainer.json`: コンテナユーザーを `cuser` → `user` に変更
  - マウントターゲット全パス変更
  - `remoteUser` 変更
  - `dprint.path` 更新
  - `alias cc` から `--dangerously-skip-permissions` を削除 (ユーザー変更で不要)
- `CLAUDE.md`: Artifacts Convention セクションを追加
  - `subagent-driven-development` で使う `.claude/artifacts/` 規約を明文化
- `.mise/tasks.toml`: `check:no-plans` タスクを改善
  - `status: active` な `PLAN.md` を持つタスクディレクトリをスキップ
  - `${#rejected[@]}` が Tera テンプレートに誤認識される問題を修正

## テスト計画

- [ ] devcontainer でビルド・起動確認
- [ ] Claude Code を起動して plugin が `/home/user/.claude` でロードされることを確認
- [ ] `mise run check:no-plans` が active タスクディレクトリをスキップすることを確認