### PR TITLE
fix(release-manager): use context.sha for tag target in create-tag

### DIFF
--- a/.github/workflows/release-manager.yaml
+++ b/.github/workflows/release-manager.yaml
@@ -298,12 +298,11 @@ jobs:
               if (e.status !== 404) throw e;
             }
 
-            // Resolve release/next HEAD
-            const { data: branchRef } = await github.request('GET /repos/{owner}/{repo}/git/ref/heads/release/next', {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-            const commitSha = branchRef.object.sha;
+            // Use the push event SHA as the tag target.
+            // release/next may already be auto-deleted when GitHub merges the PR,
+            // so reading it is unreliable. context.sha is the merge commit on main,
+            // which is exactly the commit that should carry the release tag.
+            const commitSha = context.sha;
 
             // Create annotated tag object (server-side, no GPG key required)
             const { data: tagObj } = await github.rest.git.createTag({
@@ -321,11 +320,17 @@ jobs:
               sha: tagObj.sha,
             });
 
-            // Delete release/next branch so the next feature push creates a fresh one
-            await github.request('DELETE /repos/{owner}/{repo}/git/refs/heads/release/next', {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
+            // Delete release/next if it still exists (auto-delete may have beaten us).
+            // GitHub returns 422 (not 404) when deleting a non-existent ref in some
+            // API versions, so both are treated as "already gone".
+            try {
+              await github.request('DELETE /repos/{owner}/{repo}/git/refs/heads/release/next', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+            } catch (e) {
+              if (e.status !== 404 && e.status !== 422) throw e;
+            }
 
             core.setOutput('tag', tag);
 


### PR DESCRIPTION
## 概要

- PR マージ時に GitHub が `release/next` ブランチを自動削除するため、`create-tag` ジョブが実行される頃にはブランチが存在せず 404 エラーが発生していた
- タグ対象コミットの SHA を `release/next` HEAD から取得するのをやめ、`context.sha` (push イベントの HEAD = マージコミット) から取得するように変更
- `deleteRef` の 404/422 も try/catch で gracefully に処理 (すでに自動削除済みの場合に失敗しない)

## 根本原因

run [#26898674270](https://github.com/naa0yama/boilerplate-rust/actions/runs/26898674270) で以下のエラーが発生:

```
GET /repos/naa0yama/boilerplate-rust/git/ref/heads/release/next - 404
RequestError [HttpError]: Not Found
```

`release/next` ブランチは PR #550 のマージ後に GitHub が自動削除した。`create-tag` はその後に実行されるため、ブランチは存在しない。

## テスト計画

- [x] `actionlint` + `zizmor` + `ghalint` パス (`mise run lint:gh`)
- [x] `mise run pre-commit` パス
- [ ] 次回リリースサイクルで `create-tag` ジョブの成功を確認 (v0.1.17 タグ作成を観測)