### PR TITLE
fix(release-manager): create draft GitHub Release in create-tag job

### DIFF
--- a/.github/workflows/release-manager.yaml
+++ b/.github/workflows/release-manager.yaml
@@ -320,6 +320,16 @@ jobs:
               sha: tagObj.sha,
             });
 
+            // Create a draft GitHub Release so upload-release-assets can attach binaries.
+            // (upload-release-assets expects the release to exist before it runs.)
+            await github.rest.repos.createRelease({
+              ...context.repo,
+              tag_name: tag,
+              name: tag,
+              draft: true,
+              generate_release_notes: true,
+            });
+
             // Delete release/next if it still exists (auto-delete may have beaten us).
             // GitHub returns 422 (not 404) when deleting a non-existent ref in some
             // API versions, so both are treated as "already gone".


### PR DESCRIPTION
## 概要

- `create-tag` ジョブが git tag のみ作成し draft GitHub Release を作っていなかったため、`upload-release-assets` の `gh release view v0.1.18` が失敗していた
- `repos.createRelease({ draft: true, generate_release_notes: true })` を追加し、tagpr と同等のドラフトリリースを事前作成するように修正

## 根本原因

run [#26929743214](https://github.com/naa0yama/boilerplate-rust/actions/runs/26929743214) で以下のエラーが発生:

```
##[error]Release creation failed for tag v0.1.18
```

`upload-release-assets/action.yaml` の `upload-assets` ステップで `gh release view "${TAG}"` を実行しているが、リリースが存在しないため失敗。コメントに `# Verify the release exists (tagpr creates it as draft before this workflow runs)` とある通り、tagpr が自動作成していたドラフトリリースを自前で作る必要がある。

## テスト計画

- [x] `actionlint` + `zizmor` + `ghalint` パス (`mise run lint:gh`)
- [x] `mise run pre-commit` パス
- [ ] 次回リリースサイクルで `Upload Release Assets` ジョブの成功を確認