### PR TITLE
fix(release-manager): harden workflow with idempotency fixes

### DIFF
--- a/.github/actions/upload-release-assets/action.yaml
+++ b/.github/actions/upload-release-assets/action.yaml
@@ -135,7 +135,13 @@ runs:
         release_url="$(gh release view "${TAG}" --json url --jq '.url')"
         echo "Release found: ${release_url}"
 
-        gh release upload "${TAG}" release-assets/* --clobber
+        if ! gh release upload "${TAG}" release-assets/* --clobber 2>upload.err; then
+          if grep -qE '(already_exists|immutable|422)' upload.err; then
+            echo "Assets already present and release immutable — accepting."
+          else
+            cat upload.err; exit 1
+          fi
+        fi
         echo "url=${release_url}" >> "$GITHUB_OUTPUT"
 
     - name: Publish release
@@ -145,7 +151,13 @@ runs:
         TAG: ${{ inputs.tag }}
       run: |
         set -euo pipefail
-        gh release edit "${TAG}" --draft=false --latest
+        if ! gh release edit "${TAG}" --draft=false --latest 2>edit.err; then
+          if grep -qiE '(not.*draft|already.*published|immutable)' edit.err; then
+            echo "Release already published — no-op."
+          else
+            cat edit.err; exit 1
+          fi
+        fi
         echo "Release ${TAG} published successfully"
 
     - name: Release summary

--- a/.github/graft/config.yaml
+++ b/.github/graft/config.yaml
@@ -363,8 +363,10 @@ files:
     strategy: create_only
   - path: .github/release.yml
     strategy: replace
-  - path: .github/tagpr-template.md
+  - path: .github/release-manager-pr-template.md
     strategy: replace
+  - path: .github/tagpr-template.md
+    strategy: delete
 
   # .github/graft
   - path: .github/graft/patches/.gitkeep

--- a/.github/release-manager-pr-template.md
+++ b/.github/release-manager-pr-template.md
@@ -13,3 +13,6 @@ Release for {{.NextVersion}}
 > | ------------- | ----- | ----------------- |
 > | `tagpr:minor` | minor | `0.1.4` → `0.2.0` |
 > | `tagpr:major` | major | `0.1.4` → `1.0.0` |
+
+<!-- release-manager:notes -->
+<!-- 以下に追記した内容は自動更新で上書きされません -->

--- a/.github/workflows/release-manager.yaml
+++ b/.github/workflows/release-manager.yaml
@@ -22,6 +22,8 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       is_release_merge: ${{ steps.detect.outputs.is_release_merge }}
       skip: ${{ steps.detect.outputs.skip }}
@@ -72,6 +74,9 @@ jobs:
       (github.event_name != 'pull_request' && needs.detect.outputs.is_release_merge == 'false' && needs.detect.outputs.skip != 'true'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    concurrency:
+      group: release-manager-prepare-pr
+      cancel-in-progress: false
     permissions:
       contents: write # Required to push release/next branch via REST API
       pull-requests: write # Required to create and update release PR
@@ -105,8 +110,20 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels) }}
         run: |
+          set -euo pipefail
+
           # Step 1: Read current version from main
           CURRENT=$(grep -m1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+
+          # Fix 10: guard against crates with their own version declarations
+          violators=$(find crates -name Cargo.toml -exec grep -l '^version = "' {} \; 2>/dev/null || true)
+          if [ -n "${violators}" ]; then
+            echo "::error::release-manager only supports workspace-inherited versions."
+            echo "The following crates declare their own version:"
+            echo "${violators}"
+            echo "Convert them to 'version.workspace = true' to use release-manager."
+            exit 1
+          fi
 
           # Step 2: Determine bump type from labels
           if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
@@ -130,12 +147,13 @@ jobs:
           echo "CURRENT=${CURRENT}" >> "$GITHUB_ENV"
           echo "NEXT=${NEXT}"       >> "$GITHUB_ENV"
 
-          # Step 4: Bump version in Cargo.toml and regenerate Cargo.lock
+          # Step 4: Bump version in Cargo.toml and update lockfile (workspace members only)
           sed -i "s/^version = \"${CURRENT}\"/version = \"${NEXT}\"/" Cargo.toml
-          cargo generate-lockfile
+          cargo update --workspace
 
-          # Step 5: Find previous tag
-          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          # Step 5: Find previous tag via REST API (avoids git history depth issues)
+          PREV_TAG=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" \
+                     --jq '.tag_name' 2>/dev/null || echo "")
 
           # Step 6: Generate changelog via GitHub Release Notes API
           CHANGELOG=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
@@ -227,18 +245,29 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          body=$(python3 - <<'PYEOF'
-          import os
-          changelog = open('/tmp/release-changelog.md').read()
-          tmpl = open('.github/tagpr-template.md').read()
-          print(tmpl
-            .replace('{{.NextVersion}}', f'v{os.environ["NEXT"]}')
-            .replace('{{.Changelog}}',   changelog))
-          PYEOF
-          )
+          set -euo pipefail
 
-          PR_NUM=$(gh pr list --head release/next --state open --json number \
-                   --jq '.[0].number // empty')
+          # Fix 9: ensure labels exist (idempotent; --force updates color only)
+          gh label create tagpr       --color ededed --force >/dev/null 2>&1 || true
+          gh label create tagpr:minor --color ededed --force >/dev/null 2>&1 || true
+          gh label create tagpr:major --color ededed --force >/dev/null 2>&1 || true
+
+          # Render template: substitute placeholders via bash parameter expansion
+          changelog=$(cat /tmp/release-changelog.md)
+          tmpl=$(cat .github/release-manager-pr-template.md)
+          body="${tmpl//\{\{.NextVersion\}\}/v${NEXT}}"
+          body="${body//\{\{.Changelog\}\}/${changelog}}"
+
+          # Fix 7: preserve user-editable section below marker
+          marker='<!-- release-manager:notes -->'
+          pr_info=$(gh pr list --head release/next --state open \
+                    --json number,body --jq '.[0] // empty')
+          existing=$(printf '%s' "${pr_info}" | jq -r '.body // empty')
+          PR_NUM=$(printf '%s' "${pr_info}" | jq -r '.number // empty')
+          if [[ "${existing}" == *"${marker}"* ]]; then
+            notes="${existing#*"${marker}"}"
+            body="${body%%"${marker}"*}${marker}${notes}"
+          fi
 
           if [ -n "${PR_NUM}" ]; then
             gh pr edit "${PR_NUM}" \
@@ -274,7 +303,7 @@ jobs:
     permissions:
       contents: write # Required to create tags and delete release/next branch
     steps:
-      - name: Create annotated tag and clean up release branch
+      - name: Create lightweight tag and clean up release branch
         id: tag
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -285,64 +314,69 @@ jobs:
             // (e.g., heads/release/next) to prevent Octokit from URL-encoding them.
             const tag = process.env.RELEASE_TAG;
 
-            // Guard: skip if tag was created by a concurrent run
-            try {
-              await github.request(`GET /repos/{owner}/{repo}/git/ref/tags/${tag}`, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-              });
-              core.warning(`Tag ${tag} already exists — skipping creation.`);
-              core.setOutput('tag', tag);
-              return;
-            } catch (e) {
-              if (e.status !== 404) throw e;
-            }
-
             // Use the push event SHA as the tag target.
             // release/next may already be auto-deleted when GitHub merges the PR,
             // so reading it is unreliable. context.sha is the merge commit on main,
             // which is exactly the commit that should carry the release tag.
             const commitSha = context.sha;
 
-            // Create annotated tag object (server-side, no GPG key required)
-            const { data: tagObj } = await github.rest.git.createTag({
-              ...context.repo,
-              tag,
-              message: `Release ${tag}`,
-              object: commitSha,
-              type: 'commit',
-            });
+            // Fix 1 + Fix 8 + Fix 12(b): tag existence → Release state → output decision
+            let tagExists = false;
+            try {
+              await github.request(`GET /repos/{owner}/{repo}/git/ref/tags/${tag}`, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              tagExists = true;
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
 
-            // Create the ref that makes the tag visible
-            await github.rest.git.createRef({
-              ...context.repo,
-              ref: `refs/tags/${tag}`,
-              sha: tagObj.sha,
-            });
+            if (!tagExists) {
+              // Fix 11: lightweight tag — ref points directly to the signed merge commit
+              // (avoids annotated tag object which cannot be GPG-signed with GITHUB_TOKEN)
+              await github.rest.git.createRef({
+                ...context.repo,
+                ref: `refs/tags/${tag}`,
+                sha: commitSha,
+              });
+            }
 
-            // Create a draft GitHub Release so upload-release-assets can attach binaries.
-            // (upload-release-assets expects the release to exist before it runs.)
-            await github.rest.repos.createRelease({
-              ...context.repo,
-              tag_name: tag,
-              name: tag,
-              draft: true,
-              generate_release_notes: true,
-            });
+            // Fix 1 + Fix 8: check Release state and recover if missing
+            let shouldRunRelease = true;
+            try {
+              const { data: rel } = await github.rest.repos.getReleaseByTag(
+                { ...context.repo, tag });
+              if (!rel.draft) {
+                // Published & immutable — assets already complete, skip release job
+                core.warning(`Release ${tag} already published; skipping release job.`);
+                shouldRunRelease = false;
+              }
+              // draft → continue (allows assets to be re-uploaded with --clobber)
+            } catch (e) {
+              if (e.status !== 404) throw e;
+              // Release missing — create draft so upload-release-assets can attach binaries
+              await github.rest.repos.createRelease({
+                ...context.repo,
+                tag_name: tag,
+                name: tag,
+                draft: true,
+                generate_release_notes: true,
+              });
+            }
 
             // Delete release/next if it still exists (auto-delete may have beaten us).
-            // GitHub returns 422 (not 404) when deleting a non-existent ref in some
-            // API versions, so both are treated as "already gone".
+            // Fix 12(a): also tolerate 403 from branch immutability rulesets.
             try {
               await github.request('DELETE /repos/{owner}/{repo}/git/refs/heads/release/next', {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
               });
             } catch (e) {
-              if (e.status !== 404 && e.status !== 422) throw e;
+              if (![404, 422, 403].includes(e.status)) throw e;
             }
 
-            core.setOutput('tag', tag);
+            core.setOutput('tag', shouldRunRelease ? tag : '');
 
   release:
     name: Build and Release

--- a/docs/specs/components/release-manager.md
+++ b/docs/specs/components/release-manager.md
@@ -13,12 +13,12 @@ required 120s polling workaround.
 
 ## File Layout
 
-| Path                                     | Role                                                               |
-| ---------------------------------------- | ------------------------------------------------------------------ |
-| `.github/workflows/release-manager.yaml` | Main workflow (replaces `tagpr.yaml`)                              |
-| `.github/workflows/release.yaml`         | Build + upload; called unchanged via `workflow_call`               |
-| `.github/tagpr-template.md`              | PR body template (reused, Go template syntax replaced via python3) |
-| `.github/release.yml`                    | GitHub Release Notes category config                               |
+| Path                                     | Role                                                           |
+| ---------------------------------------- | -------------------------------------------------------------- |
+| `.github/workflows/release-manager.yaml` | Main workflow (replaces `tagpr.yaml`)                          |
+| `.github/workflows/release.yaml`         | Build + upload; called unchanged via `workflow_call`           |
+| `.github/release-manager-pr-template.md` | PR body template (placeholders substituted via bash expansion) |
+| `.github/release.yml`                    | GitHub Release Notes category config                           |
 
 Deleted: `.tagpr`, `.tagpr-version-bump.sh`
 
@@ -95,8 +95,12 @@ respects the existing `.github/release.yml` category configuration.
 
 ### Tag creation
 
-Uses `POST /git/tags` (annotated tag object) + `POST /git/refs` — server-side,
-no GPG key required. Does NOT use `git tag -a` + push.
+Uses `POST /git/refs` only — lightweight tag pointing directly at the signed
+merge commit. The commit's web-flow "Verified" status carries through to the
+tag ref without any GPG key setup (identical to tagpr v0.1.14 behaviour).
+
+Annotated tags (`POST /git/tags`) were dropped because GITHUB_TOKEN cannot
+GPG-sign them, which caused the tag to appear "Unverified" in the GitHub UI.
 
 ## Idempotency Invariants
 
@@ -114,6 +118,12 @@ concurrency:
   cancel-in-progress: false # tag creation must not be cancelled
 ```
 
+`prepare-pr` has an additional **job-level** concurrency group
+`release-manager-prepare-pr` (cancel-in-progress: false). The workflow-level
+group includes `github.ref`, so push and pull_request events land in separate
+groups; without the job-level group, two concurrent `prepare-pr` runs could
+race to force-update `release/next`.
+
 ## Bump Labels
 
 | Label         | Effect               |
@@ -124,14 +134,27 @@ concurrency:
 
 Label names kept identical to tagpr for backward compatibility.
 
-## Open Questions
+## Deployment Checklist
 
-1. **sed targeting**: `^version = "X.Y.Z"` matches only `[workspace.package]`
-   in the current Cargo.toml structure. Re-verify if the file structure changes.
-2. **REST API Verified status**: Commits via `POST /git/commits` with
-   GITHUB_TOKEN should appear "Verified". Confirm on first deployment against
-   branch protection "require signed commits". Escalate to GitHub App token
-   if unverified.
-3. **Tag GPG signing**: `POST /git/tags` creates an annotated tag server-side
-   but does NOT GPG-sign it. Confirm whether the repository enforces signed
-   tags.
+For each new project rolling out release-manager:
+
+- [ ] All crates under `crates/` use `version.workspace = true` (no own `version = "..."`)
+- [ ] Root `Cargo.toml` has `[workspace.package] version = "X.Y.Z"`
+- [ ] Guard passes on first `prepare-pr` run (check job logs)
+- [ ] Tag ruleset `Restrict updates` / `Restrict deletions` — ON recommended
+- [ ] Tag ruleset `Require signed commits` — **OFF** (lightweight tag inherits commit signature; cannot sign the ref itself)
+- [ ] If using release immutability ruleset, confirm first publish succeeds before enabling
+- [ ] `release/next` branch must NOT have `Restrict deletions` ruleset (create-tag deleteRef must work)
+
+## Design Decisions Log
+
+| Fix    | Decision                                                                                   |
+| ------ | ------------------------------------------------------------------------------------------ |
+| Fix 2  | `git describe` replaced by `gh api releases/latest` — avoids shallow clone failures        |
+| Fix 3  | Job-level concurrency group on prepare-pr serialises push vs PR event runs                 |
+| Fix 5  | `cargo update --workspace` instead of `generate-lockfile` — updates only workspace members |
+| Fix 7  | `<!-- release-manager:notes -->` marker preserves user-editable PR body content            |
+| Fix 9  | `gh label create --force` on each prepare-pr run — idempotent label bootstrap              |
+| Fix 10 | Guard rejects crates with own `version = "..."` — unsupported by workspace-based bump      |
+| Fix 11 | Lightweight tag (ref → commit SHA) restores "Verified" status lost with annotated tags     |
+| Fix 12 | 403/422 tolerance on deleteRef; published-Release detection skips redundant release job    |


### PR DESCRIPTION
## 概要

`release-manager` workflow の idempotency と verified tag を保証し、 Python 依存を削除、 PR 本文のユーザー追記保持と下流リポへの rename 配布を一括で反映する。

## 主な変更

- **Tag 生成**: annotated tag (`POST /git/tags`) を廃止し lightweight tag (`POST /git/refs` のみ) へ変更 (Fix 11)。 `GITHUB_TOKEN` で GPG 署名できない問題を回避し、 merge commit の web-flow Verified を tag ref に継承させる。
- **Release state チェック**: `getReleaseByTag` で公開済 Release を検出して release job を skip (Fix 1/8/12b)、 deleteRef の 403 (branch immutability ruleset) を許容 (Fix 12a)。
- **PR body 生成**: Python heredoc を bash パラメータ展開へ置換。 `.github/tagpr-template.md` を `.github/release-manager-pr-template.md` にリネーム。 `<!-- release-manager:notes -->` marker で PR 本文のユーザー追記を保持 (Fix 7)。
- **Concurrency**: prepare-pr に job-level concurrency `release-manager-prepare-pr` を追加 (Fix 3)。 workflow-level group が `github.ref` 含むため push と pull_request が別グループになり、 `release/next` force-update が競合する問題を解消。
- **Workspace guard**: `crates/*/Cargo.toml` に独自 `version = "..."` を持つ crate を拒否 (Fix 10)。
- **Lockfile / 前回 tag 取得**: `cargo update --workspace` (Fix 5)、 `gh api releases/latest` (Fix 2) へ変更。 fetch-depth: 1 + tagless first run でも動作する。
- **Label bootstrap**: `gh label create --force` で冪等化 (Fix 9)。
- **Upload immutability**: `gh release upload` / `edit --draft=false` の 422 / immutable エラーを許容 (Fix 12)。
- **graft 配布**: 下流リポの旧 `tagpr-template.md` を `strategy: delete` で cleanup。
- **Spec 更新**: `Open Questions` を `Deployment Checklist` + `Design Decisions Log` に置換。

## Test plan

- [ ] `mise run lint:gh` pass (手元で確認済み)
- [ ] `mise run pre-commit` pass (手元で確認済み)
- [ ] 次回 release で lightweight tag が GitHub UI 上 "Verified" 表示になることを確認
- [ ] `release/next` PR 本文の marker 以下にユーザー追記が保持されることを確認
- [ ] 下流リポ取り込み後に旧 `tagpr-template.md` が削除されることを確認