### PR TITLE
fix(release-manager): guard jq against null labels on push event

### DIFF
--- a/.github/workflows/release-manager.yaml
+++ b/.github/workflows/release-manager.yaml
@@ -133,7 +133,7 @@ jobs:
           else
             BUMP=$(gh pr list --head release/next --state open \
                    --json labels --jq \
-                   '[.[0].labels[].name | select(startswith("tagpr:"))] | first // "patch"' \
+                   '[(.[0].labels // [])[].name | select(startswith("tagpr:"))] | first // "patch"' \
                    | sed 's/tagpr://')
           fi
           # Step 3: Calculate next version


### PR DESCRIPTION
## 概要

`release-manager.yaml` の `prepare-pr` ジョブが push event 直後の最初の実行で必ず失敗するバグを修正。

## 不具合

push event で `release/next` PR がまだ存在しないとき、 `gh pr list --head release/next --state open` は空配列 `[]` を返す。
そのため次の jq 式で `.[0]` が `null` となり、 `.labels[]` で `cannot iterate over: null` エラーで落ちる。

```jq
[.[0].labels[].name | select(startswith("tagpr:"))] | first // "patch"
```

事象が再現したラン: https://github.com/naa0yama/boilerplate-rust/actions/runs/26942614426

## 修正

`(.[0].labels // [])` で labels 不在時に空配列にフォールバックさせる。
これにより patch bump がデフォルトとして選ばれる従来挙動が成立。

```diff
- '[.[0].labels[].name | select(startswith("tagpr:"))] | first // "patch"'
+ '[(.[0].labels // [])[].name | select(startswith("tagpr:"))] | first // "patch"'
```

## テスト計画

- [x] `mise run lint:gh` 通過
- [x] `mise run pre-commit` 通過
- [ ] マージ後、 prepare-pr ジョブが `release/next` PR を作成することを確認