### PR TITLE
fix(graft): remove tagpr references and add release-manager

### DIFF
--- a/.github/actions/upload-release-assets/action.yaml
+++ b/.github/actions/upload-release-assets/action.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://www.schemastore.org/github-action.json
 name: "Upload Release Assets"
-description: "Download build artifacts and upload them to an existing GitHub release created by tagpr"
+description: "Download build artifacts and upload them to an existing GitHub release draft"
 inputs:
   tag:
     description: "Release tag"
@@ -131,7 +131,7 @@ runs:
         set -euo pipefail
         shopt -s failglob
 
-        # Verify the release exists (tagpr creates it as draft before this workflow runs)
+        # Verify the release exists (release-manager creates it as draft before this workflow runs)
         release_url="$(gh release view "${TAG}" --json url --jq '.url')"
         echo "Release found: ${release_url}"
 

--- a/.github/graft/config.yaml
+++ b/.github/graft/config.yaml
@@ -239,7 +239,6 @@ spec:
         - "k1low/gh-setup@*"
         - "k1low/octocov-action@*"
         - "mozilla-actions/sccache-action@*"
-        - "songmu/tagpr@*"
         - "swatinem/rust-cache@*"
         - "taiki-e/install-action@*"
         - "zizmorcore/zizmor-action@*"
@@ -422,18 +421,20 @@ files:
     strategy: delete
   - path: .github/workflows/prebuild-container.yaml
     strategy: delete
+  - path: .github/workflows/release-manager.yaml
+    strategy: replace
   - path: .github/workflows/release.yaml
     strategy: replace
   - path: .github/workflows/rust-ci.yaml
     strategy: replace
   - path: .github/workflows/tagpr.yaml
-    strategy: replace
+    strategy: delete
 
   # .mise
   - path: .mise/config.devcontainer.toml
     strategy: replace
   - path: .mise/config.tagpr.toml
-    strategy: replace
+    strategy: delete
   - path: .mise/overrides.toml
     strategy: create_only
   - path: .mise/tasks.toml
@@ -503,7 +504,7 @@ files:
   - path: .octocov.yml
     strategy: replace
   - path: .tagpr
-    strategy: replace
+    strategy: delete
   - path: .worktreeinclude
     strategy: replace
     preserve_markers: true

--- a/.mise/config.tagpr.toml
+++ b/.mise/config.tagpr.toml
@@ -1,2 +1,0 @@
-[env]
-RUSTC_WRAPPER = false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
-	"files.associations": {
-		".tagpr": "toml"
-	},
 	"[dockerfile]": {
 		"editor.defaultFormatter": "ms-azuretools.vscode-containers"
 	},

--- a/docs/specs/components/release-manager.md
+++ b/docs/specs/components/release-manager.md
@@ -20,7 +20,7 @@ required 120s polling workaround.
 | `.github/release-manager-pr-template.md` | PR body template (placeholders substituted via bash expansion) |
 | `.github/release.yml`                    | GitHub Release Notes category config                           |
 
-Deleted: `.tagpr`, `.tagpr-version-bump.sh`
+Deleted: `.tagpr`, `.tagpr-version-bump.sh`, `.mise/config.tagpr.toml`
 
 ## Workflow Triggers
 


### PR DESCRIPTION
## 概要

- `graft/config.yaml` に `release-manager.yaml` を `strategy: replace` で追加 (バックポート時に伝播するよう)
- `graft/config.yaml`: `tagpr.yaml` / `.tagpr` / `.mise/config.tagpr.toml` を `strategy: delete` に変更 (バックポートから削除されるよう)
- `graft/config.yaml`: `songmu/tagpr@*` を `patterns_allowed` から削除
- `.mise/config.tagpr.toml` 本体削除 (`RUSTC_WRAPPER = false` のみの tagpr 専用死にコード)
- `.vscode/settings.json`: `.tagpr` ファイルの TOML 関連付けを削除
- `upload-release-assets/action.yaml`: description とコメントの tagpr 言及を release-manager に修正
- `docs/specs/components/release-manager.md`: Deleted リストに `.mise/config.tagpr.toml` を追記

## テスト計画

- [x] `mise run pre-commit` 通過 (fmt:check / clippy:strict / ast-grep / lint:gh / check:no-plans)
- [x] コミット GPG 署名確認 (`G` ステータス)
- [ ] graft apply でバックポートプロジェクトの `tagpr.yaml` / `.tagpr` / `.mise/config.tagpr.toml` が削除されること
- [ ] graft apply でバックポートプロジェクトに `release-manager.yaml` が同期されること