### PR TITLE
refactor(release-manager): rename tagpr labels to release-pr and bump:*

### DIFF
--- a/.github/graft/config.yaml
+++ b/.github/graft/config.yaml
@@ -62,15 +62,15 @@ spec:
       description: Backport from template or upstream repository
       color: 0e8a16
 
-    # tagpr
-    - name: tagpr
-      description: Created by tagpr for release management
+    # release-manager
+    - name: release-pr
+      description: Created by release-manager for release management
       color: "5319e7"
-    - name: tagpr:minor
-      description: Bump minor version (tagpr auto-label)
+    - name: bump:minor
+      description: Bump minor version (release-manager auto-label)
       color: "5319e7"
-    - name: tagpr:major
-      description: Bump major version (tagpr auto-label)
+    - name: bump:major
+      description: Bump major version (release-manager auto-label)
       color: "5319e7"
     - name: ignore-for-release
       description: Exclude from release notes

--- a/.github/release-manager-pr-template.md
+++ b/.github/release-manager-pr-template.md
@@ -9,10 +9,10 @@ Release for {{.NextVersion}}
 > [!NOTE]
 > バージョンバンプはデフォルトで **patch** です。変更したい場合はこの PR に以下のラベルを付けてください:
 >
-> | Label         | Bump  | Example           |
-> | ------------- | ----- | ----------------- |
-> | `tagpr:minor` | minor | `0.1.4` → `0.2.0` |
-> | `tagpr:major` | major | `0.1.4` → `1.0.0` |
+> | Label        | Bump  | Example           |
+> | ------------ | ----- | ----------------- |
+> | `bump:minor` | minor | `0.1.4` → `0.2.0` |
+> | `bump:major` | major | `0.1.4` → `1.0.0` |
 
 <!-- release-manager:notes -->
 <!-- 以下に追記した内容は自動更新で上書きされません -->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,7 +3,7 @@ changelog:
   exclude:
     labels:
       - ignore-for-release
-      - tagpr
+      - release-pr
 
   categories:
     - title: Features 🎉

--- a/.github/workflows/release-manager.yaml
+++ b/.github/workflows/release-manager.yaml
@@ -128,13 +128,13 @@ jobs:
           # Step 2: Determine bump type from labels
           if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
             BUMP=$(echo "${PR_LABELS_JSON}" \
-                   | jq -r '[.[].name | select(startswith("tagpr:"))] | first // "patch"' \
-                   | sed 's/tagpr://')
+                   | jq -r '[.[].name | select(startswith("bump:"))] | first // "patch"' \
+                   | sed 's/bump://')
           else
             BUMP=$(gh pr list --head release/next --state open \
                    --json labels --jq \
-                   '[(.[0].labels // [])[].name | select(startswith("tagpr:"))] | first // "patch"' \
-                   | sed 's/tagpr://')
+                   '[(.[0].labels // [])[].name | select(startswith("bump:"))] | first // "patch"' \
+                   | sed 's/bump://')
           fi
           # Step 3: Calculate next version
           IFS='.' read -r MAJ MIN PAT <<< "$CURRENT"
@@ -248,9 +248,9 @@ jobs:
           set -euo pipefail
 
           # Fix 9: ensure labels exist (idempotent; --force updates color only)
-          gh label create tagpr       --color ededed --force >/dev/null 2>&1 || true
-          gh label create tagpr:minor --color ededed --force >/dev/null 2>&1 || true
-          gh label create tagpr:major --color ededed --force >/dev/null 2>&1 || true
+          gh label create release-pr  --color ededed --force >/dev/null 2>&1 || true
+          gh label create bump:minor  --color ededed --force >/dev/null 2>&1 || true
+          gh label create bump:major  --color ededed --force >/dev/null 2>&1 || true
 
           # Render template: substitute placeholders via bash parameter expansion
           changelog=$(cat /tmp/release-changelog.md)
@@ -279,7 +279,7 @@ jobs:
               --base main \
               --title "Release for v${NEXT}" \
               --body "${body}" \
-              --label tagpr \
+              --label release-pr \
             || {
               PR_NUM=$(gh pr list --head release/next --state open --json number \
                        --jq '.[0].number')

--- a/docs/specs/components/release-manager.md
+++ b/docs/specs/components/release-manager.md
@@ -34,7 +34,7 @@ on:
   workflow_dispatch: {}
 ```
 
-`pull_request` activates when `tagpr:minor` or `tagpr:major` is added/removed
+`pull_request` activates when `bump:minor` or `bump:major` is added/removed
 on the `release/next` PR. The `prepare-pr` job's `if:` guard filters to only
 the `release/next` head ref.
 
@@ -126,13 +126,11 @@ race to force-update `release/next`.
 
 ## Bump Labels
 
-| Label         | Effect               |
-| ------------- | -------------------- |
-| `tagpr:minor` | Minor version bump   |
-| `tagpr:major` | Major version bump   |
-| (none)        | Patch bump (default) |
-
-Label names kept identical to tagpr for backward compatibility.
+| Label        | Effect               |
+| ------------ | -------------------- |
+| `bump:minor` | Minor version bump   |
+| `bump:major` | Major version bump   |
+| (none)       | Patch bump (default) |
 
 ## Deployment Checklist
 


### PR DESCRIPTION
## 概要

`Songmu/tagpr` からの移行完了後も残っていた `tagpr` 接頭辞ラベルを、
`release-manager` の運用実態に合わせた名称へ統一する。

## 改名マッピング

| Before        | After         | 役割                              |
| ------------- | ------------- | --------------------------------- |
| `tagpr`       | `release-pr`  | release PR マーカー + changelog 除外 |
| `tagpr:minor` | `bump:minor`  | minor バンプ指定                   |
| `tagpr:major` | `bump:major`  | major バンプ指定                   |

## 変更ファイル

- `.github/workflows/release-manager.yaml` — jq filter, sed, label create, `--label`
- `.github/release.yml` — changelog exclude ラベル
- `.github/graft/config.yaml` — ラベル定義ブロック (backport repos へ自動伝播)
- `.github/release-manager-pr-template.md` — バンプ説明テーブル
- `docs/specs/components/release-manager.md` — Triggers 説明 + Bump Labels 表

## マージ後の手動操作

```bash
gh label create release-pr --color ededed
gh label create bump:minor  --color ededed
gh label create bump:major  --color ededed
# PR #568 に release-pr 付与、tagpr 剥がし
gh label delete tagpr
gh label delete tagpr:minor
gh label delete tagpr:major
```

backport repos は graft の `label_sync: mirror` が次回 run で自動移行。