### PR TITLE
fix(release-manager): align label colors with graft config

### DIFF
--- a/.github/workflows/release-manager.yaml
+++ b/.github/workflows/release-manager.yaml
@@ -248,9 +248,9 @@ jobs:
           set -euo pipefail
 
           # Fix 9: ensure labels exist (idempotent; --force updates color only)
-          gh label create release-pr  --color ededed --force >/dev/null 2>&1 || true
-          gh label create bump:minor  --color ededed --force >/dev/null 2>&1 || true
-          gh label create bump:major  --color ededed --force >/dev/null 2>&1 || true
+          gh label create release-pr  --color 5319e7 --force >/dev/null 2>&1 || true
+          gh label create bump:minor  --color 5319e7 --force >/dev/null 2>&1 || true
+          gh label create bump:major  --color 5319e7 --force >/dev/null 2>&1 || true
 
           # Render template: substitute placeholders via bash parameter expansion
           changelog=$(cat /tmp/release-changelog.md)


### PR DESCRIPTION
## 概要

- `release-manager.yaml` の `gh label create` で使用する `--color` 値を `ededed` → `5319e7` に修正
- `.github/graft/config.yaml` の color 定義 (`5319e7`) と一致させることで、graft sync のたびにラベル色が上書きされる問題を解消

## 経緯

PR #580 で `tagpr` → `release-pr` / `bump:minor` / `bump:major` にラベル改名した際、`release-manager.yaml` のラベル作成コマンドに `ededed` (薄いグレー) を指定したが、`graft/config.yaml` では `5319e7` (紫) が定義されていた。graft sync を実行すると毎回色が上書きされる状態になっていた。

## 変更内容

`.github/workflows/release-manager.yaml` の3行:

```
gh label create release-pr  --color 5319e7 --force
gh label create bump:minor  --color 5319e7 --force
gh label create bump:major  --color 5319e7 --force
```

## テスト

- [ ] CI Gate pass
- [ ] `gh label list` で `release-pr` / `bump:minor` / `bump:major` の color が `5319e7` であることを確認