### PR TITLE
fix(release-manager): guard PREV_TAG and clarify cargo update intent

### DIFF
--- a/.github/workflows/release-manager.yaml
+++ b/.github/workflows/release-manager.yaml
@@ -147,7 +147,7 @@ jobs:
           echo "CURRENT=${CURRENT}" >> "$GITHUB_ENV"
           echo "NEXT=${NEXT}"       >> "$GITHUB_ENV"
 
-          # Step 4: Bump version in Cargo.toml and update lockfile (workspace members only)
+          # Step 4: Bump version in Cargo.toml and update lockfile
           sed -i "s/^version = \"${CURRENT}\"/version = \"${NEXT}\"/" Cargo.toml
           cargo update --workspace
 
@@ -156,9 +156,11 @@ jobs:
                      --jq '.tag_name' 2>/dev/null || echo "")
 
           # Step 6: Generate changelog via GitHub Release Notes API
+          PREV_TAG_ARG=()
+          [ -n "${PREV_TAG}" ] && PREV_TAG_ARG=(-f "previous_tag_name=${PREV_TAG}")
           CHANGELOG=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
             -f "tag_name=v${NEXT}" \
-            -f "previous_tag_name=${PREV_TAG}" \
+            "${PREV_TAG_ARG[@]}" \
             --jq '.body')
 
           # Write changelog to file for safe multiline handoff

--- a/docs/specs/components/release-manager.md
+++ b/docs/specs/components/release-manager.md
@@ -93,6 +93,9 @@ double-bump on idempotent re-runs. `sed` targets `^version = "X.Y.Z"` at
 GitHub Release Notes API (`POST /repos/{owner}/{repo}/releases/generate-notes`)
 respects the existing `.github/release.yml` category configuration.
 
+`previous_tag_name` is omitted when `PREV_TAG` is empty (first release), so
+the API generates notes from repository creation rather than returning an error.
+
 ### Tag creation
 
 Uses `POST /git/refs` only — lightweight tag pointing directly at the signed
@@ -146,13 +149,13 @@ For each new project rolling out release-manager:
 
 ## Design Decisions Log
 
-| Fix    | Decision                                                                                   |
-| ------ | ------------------------------------------------------------------------------------------ |
-| Fix 2  | `git describe` replaced by `gh api releases/latest` — avoids shallow clone failures        |
-| Fix 3  | Job-level concurrency group on prepare-pr serialises push vs PR event runs                 |
-| Fix 5  | `cargo update --workspace` instead of `generate-lockfile` — updates only workspace members |
-| Fix 7  | `<!-- release-manager:notes -->` marker preserves user-editable PR body content            |
-| Fix 9  | `gh label create --force` on each prepare-pr run — idempotent label bootstrap              |
-| Fix 10 | Guard rejects crates with own `version = "..."` — unsupported by workspace-based bump      |
-| Fix 11 | Lightweight tag (ref → commit SHA) restores "Verified" status lost with annotated tags     |
-| Fix 12 | 403/422 tolerance on deleteRef; published-Release detection skips redundant release job    |
+| Fix    | Decision                                                                                                                                             |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Fix 2  | `git describe` replaced by `gh api releases/latest` — avoids shallow clone failures                                                                  |
+| Fix 3  | Job-level concurrency group on prepare-pr serialises push vs PR event runs                                                                           |
+| Fix 5  | `cargo update --workspace` instead of `generate-lockfile` — updates workspace members and captures pending transitive dep upgrades in the release PR |
+| Fix 7  | `<!-- release-manager:notes -->` marker preserves user-editable PR body content                                                                      |
+| Fix 9  | `gh label create --force` on each prepare-pr run — idempotent label bootstrap                                                                        |
+| Fix 10 | Guard rejects crates with own `version = "..."` — unsupported by workspace-based bump                                                                |
+| Fix 11 | Lightweight tag (ref → commit SHA) restores "Verified" status lost with annotated tags                                                               |
+| Fix 12 | 403/422 tolerance on deleteRef; published-Release detection skips redundant release job                                                              |


### PR DESCRIPTION
## Summary

- Skip `previous_tag_name` in the `generate-notes` API call when no prior release exists, preventing full-history changelogs on first release
- Remove misleading "workspace members only" from the Step 4 comment; `docs/specs/components/release-manager.md` already documents the intentional transitive-dep upgrade behavior of `cargo update --workspace`

## Test plan

- [ ] CI グリーンを確認
- [ ] 初回リリースをシミュレートして CHANGELOG 生成が全履歴を含まないことをローカル確認