### PR TITLE
build(docker): add python3.13-venv to development stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,6 +135,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 	echo "**** Dependencies ****" && \
 	set -euxo pipefail && \
 	apt-get -y install --no-install-recommends \
+	python3.13-venv \
 	shellcheck
 
 # User level settings


### PR DESCRIPTION
## Summary

- `development` ステージに `python3.13-venv` を追加
- `security-guidance` Claude Code plugin が `claude_agent_sdk` インストール用 venv を作成するために必要
- `python3` 本体は trixie ベースイメージに既存のため追加不要 (最小限を維持)

## 背景

`python3 -m venv` 実行時に `ensurepip` が見つからずエラー (`BUILD_FAILED`)。
これにより UserPromptSubmit フックが "no working Python 3 interpreter found" を出力していた。

## Test plan

- [ ] コンテナをビルドして `python3 -m venv /tmp/test && echo OK` が通ることを確認