### PR TITLE
fix(mise): stop check:no-plans exempting all of plans/ via stale PLAN.md

### DIFF
--- a/.github/graft/config.yaml
+++ b/.github/graft/config.yaml
@@ -440,6 +440,8 @@ files:
     strategy: replace
   - path: .mise/config.tagpr.toml
     strategy: delete
+  - path: .mise/lib/nextest-env.sh
+    strategy: replace
   - path: .mise/overrides.toml
     strategy: create_only
   - path: .mise/tasks.toml

--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,11 @@ target
 .claude/*.local.json
 .claude/artifacts/
 .claude/scheduled_tasks.lock
-.claude/skills/cc-plugin-claude-*
+.claude/skills/cc-plugin-*/
 .claude/skills/deps-sync-rust-pwa-stack/
-.claude/skills/lib-*/SKILL.md
-.claude/skills/tool-*/SKILL.md
+.claude/skills/lib-*/*.md
+.claude/skills/mise-*/*.md
+.claude/skills/tool-*/*.md
 
 # local Lefthook
 lefthook-local.yml

--- a/.mise/lib/nextest-env.sh
+++ b/.mise/lib/nextest-env.sh
@@ -1,0 +1,10 @@
+# Shared nextest thread-count and quiet-flag resolution.
+# Source-only — not meant to be executed directly. Sourced by test/coverage
+# tasks in .mise/tasks.toml to avoid duplicating the same cpu/thread math in
+# four separate `run` scripts.
+_cpus=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
+_threads=$(( _cpus * 7 / 10 < 1 ? 1 : _cpus * 7 / 10 ))
+[[ "${GITHUB_ACTIONS:-}" == "true" ]] && _threads="$_cpus"
+
+_quiet=""
+[[ "${CLAUDECODE:-}" == "1" ]] && _quiet="--cargo-quiet --cargo-quiet --status-level fail"

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -90,7 +90,15 @@ depends = ["clean:sweep", "fmt:check", "clippy:strict", "ast-grep", "lint:gh", "
 
 ["pre-push"]
 description = "Pre-push checks (comprehensive)"
-depends = ["lint", "test", "coverage", "build:release", "lint:gh"]
+# `coverage` already runs the full nextest suite (instrumented); depending on
+# `test` too would build and run everything a second time on the stable
+# toolchain, doubling target/ disk usage for no additional signal locally.
+# NOTE: this means stable-toolchain test execution (as opposed to the
+# nightly toolchain `coverage` uses) is no longer exercised anywhere —
+# CI's `test` job also only calls `mise run coverage`, and `cross-check`
+# only runs `cargo check` (compile-only) on stable. Run `mise run test`
+# manually if stable-vs-nightly behavioral parity needs to be checked.
+depends = ["lint", "coverage", "build:release", "lint:gh"]
 
 [setup]
 description = "Initial project setup"
@@ -247,11 +255,25 @@ run = """
 set -euo pipefail
 
 rustup component add llvm-tools-preview --toolchain nightly-2026-03-15
-quiet=""; [[ "${CLAUDECODE:-}" == "1" ]] && quiet="--cargo-quiet --cargo-quiet --status-level fail"
-_cpus=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
-_threads=$(( _cpus * 7 / 10 < 1 ? 1 : _cpus * 7 / 10 ))
-if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then _threads="$_cpus"; fi
-cargo +nightly-2026-03-15 llvm-cov nextest --all-targets --all-features --fail-under-lines 90 --lcov --output-path target/lcov.info --test-threads "$_threads" $quiet
+source "${MISE_PROJECT_ROOT}/.mise/lib/nextest-env.sh"
+
+# target/llvm-cov-target duplicates target/debug's size (instrumented rebuild
+# of every dependency); discard it once the run finishes — including on
+# failure (fail-under-lines violation, test failure, etc.), since a failed
+# instrumented build isn't worth keeping either — unless the caller opts to
+# keep it around for a follow-up `coverage:html` run.
+# WHY-NOT: `llvm-cov clean --workspace` — only removes workspace-member
+# artifacts and deliberately keeps the dependency build cache, so it frees
+# almost none of the directory's size; the plain (no-flag) form removes
+# target/llvm-cov-target entirely.
+if [[ "${COVERAGE_KEEP:-}" != "1" && "${GITHUB_ACTIONS:-}" != "true" ]]; then
+  # WHY-NOT: bare `trap 'cargo ... clean' EXIT` — when this is the last
+  # command bash runs, its own exit status becomes the script's exit status,
+  # so a transient cleanup failure would mask a successful coverage run.
+  trap 'ec=$?; cargo +nightly-2026-03-15 llvm-cov clean || echo "warning: coverage cleanup failed" >&2; exit $ec' EXIT
+fi
+
+cargo +nightly-2026-03-15 llvm-cov nextest --all-targets --all-features --fail-under-lines 90 --lcov --output-path target/lcov.info --test-threads "$_threads" $_quiet
 """
 
 ["coverage:html"]
@@ -262,10 +284,8 @@ run = """
 set -euo pipefail
 
 rustup component add llvm-tools-preview --toolchain nightly-2026-03-15
-quiet=""; [[ "${CLAUDECODE:-}" == "1" ]] && quiet="--cargo-quiet --cargo-quiet --status-level fail"
-_cpus=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
-_threads=$(( _cpus * 7 / 10 < 1 ? 1 : _cpus * 7 / 10 ))
-cargo +nightly-2026-03-15 llvm-cov nextest --all-targets --all-features --html --open --test-threads "$_threads" $quiet
+source "${MISE_PROJECT_ROOT}/.mise/lib/nextest-env.sh"
+cargo +nightly-2026-03-15 llvm-cov nextest --all-targets --all-features --html --open --test-threads "$_threads" $_quiet
 """
 
 [deny]
@@ -325,11 +345,8 @@ run = """
 #!/usr/bin/env bash
 set -euo pipefail
 
-quiet=""; [[ "${CLAUDECODE:-}" == "1" ]] && quiet="--cargo-quiet --cargo-quiet --status-level fail"
-_cpus=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
-_threads=$(( _cpus * 7 / 10 < 1 ? 1 : _cpus * 7 / 10 ))
-if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then _threads="$_cpus"; fi
-cargo nextest run --all-targets --all-features --test-threads "$_threads" $quiet "$@"
+source "${MISE_PROJECT_ROOT}/.mise/lib/nextest-env.sh"
+cargo nextest run --all-targets --all-features --test-threads "$_threads" $_quiet "$@"
 """
 
 ["test:doc"]
@@ -352,11 +369,8 @@ set -euo pipefail
 mise run o2:stop
 mise run o2
 echo 'OpenObserve restarted with clean state'
-quiet=""; [[ "${CLAUDECODE:-}" == "1" ]] && quiet="--cargo-quiet --cargo-quiet --status-level fail"
-_cpus=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
-_threads=$(( _cpus * 7 / 10 < 1 ? 1 : _cpus * 7 / 10 ))
-if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then _threads="$_cpus"; fi
-cargo nextest run --all-targets --all-features --test-threads "$_threads" $quiet
+source "${MISE_PROJECT_ROOT}/.mise/lib/nextest-env.sh"
+cargo nextest run --all-targets --all-features --test-threads "$_threads" $_quiet
 """
 
 ["test:watch"]

--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -41,7 +41,10 @@ rejected=""
 while IFS= read -r f; do
   dir=$(dirname "$f")
   plan="$dir/PLAN.md"
-  # task dir with an active PLAN.md → in progress, skip entire dir
+  # plans/ (at any depth) holds brainstorming specs, never a task-slug dir —
+  # a PLAN.md placed there must not exempt sibling spec files
+  [[ "$dir" == ".claude/artifacts/plans" || "$dir" == .claude/artifacts/plans/* ]] && plan=""
+  # task-slug dir with an active PLAN.md → in progress, skip entire dir
   if [[ -f "$plan" ]] && head -5 "$plan" | grep -q 'status: active'; then
     continue
   fi

--- a/docs/specs/architecture/testing.md
+++ b/docs/specs/architecture/testing.md
@@ -1,0 +1,55 @@
+# Testing & Coverage Strategy
+
+## Coverage Target
+
+- CI hard floor: 90% (`mise run pre-push` fails under `--fail-under-lines 90`).
+- Working target: 100% line/branch coverage. `#[coverage(off)]` is not used
+  to reach the floor — every branch gets a real test or an explicit
+  `// NOTEST(unreachable): <why>` comment (see
+  `~/.claude/skills/rust-implementation/references/coverage-tooling.md`
+  "Coverage Target Strategy").
+- `fn main` / CLI entrypoints are covered via integration tests that spawn
+  the actual binary (`assert_cmd::Command::cargo_bin`) rather than excluded
+  from coverage.
+
+## External Dependencies in Tests
+
+OTLP receivers and HTTP servers exercised in tests run as in-process fakes
+(`tokio::net::TcpListener::bind("127.0.0.1:0")` + a tiny axum handler)
+instead of a real OTLP collector or wiremock — this avoids external
+dependencies and keeps CI stable. Considered alternatives (wiremock, a real
+`o2` instance) were rejected for the same reason; not ADR-worthy since the
+approach is reversible and consistent with the existing `tests/` pattern.
+
+## brust / brust-web Coverage History
+
+Baseline on `feat/wireframe-daisyui-thumbnails` (2026-07-08): 74.16%
+(999/1347 lines). Brought to 97.01% via TDD cycles targeting each
+uncovered file (`telemetry/mod.rs`, `main.rs` Serve path, `assets.rs`,
+`trace.rs` branch coverage, `libs/http.rs` fetch success path, `main.rs`
+Run path, residual `NOTEST` cleanup). Full cycle-by-cycle breakdown lived
+in the now-absorbed `2026-07-08-test-coverage-100.md` design spec.
+
+Final state: 97.01% (90% floor cleared by +7.01%). The remaining 2.99%
+(~40 lines) is 22 `NOTEST(unreachable)` sites where adding a test would
+require mocking the OTel SDK for near-zero benefit:
+
+- `Response::builder` static status/empty-body `Err` paths
+- OTel provider shutdown/force_flush `Err` paths
+- Exhaustive `match` guards over OTel SDK metric types
+- `signal()` under `cfg(not(unix))` (non-Unix build target, not exercised
+  in CI)
+- Askama `render()` `Err` path
+- Internal test-server panic path
+- CLI exhaustive-guard branches unreachable via public API
+
+## Known Deviation: Production Code Changed for Test Enablement
+
+The Cycle A `main.rs` Serve-path integration test required `main.rs` to log
+its resolved `local_addr` (so the test can parse the actually-bound port
+when `--bind` uses port `0`) and to handle `SIGTERM`/`SIGINT` for graceful
+shutdown at test teardown. This was production code changed to make a test
+possible, not test code alone — both changes are reversible (removing the
+log line or signal handling doesn't affect runtime correctness) and are now
+part of the crate's documented CLI behavior (see
+`docs/specs/components/brust-web.md` CLI Subcommands section).

--- a/docs/specs/components/brust-web.md
+++ b/docs/specs/components/brust-web.md
@@ -90,3 +90,8 @@ src/
 
 See [otel-instrumentation.md](../architecture/otel-instrumentation.md) for the full
 3-signal specification.
+
+## Test Coverage
+
+See [testing.md](../architecture/testing.md) for the coverage strategy and
+history (baseline 74.16% → 97.01%, `NOTEST(unreachable)` policy).


### PR DESCRIPTION
## Summary

- `check:no-plans` は同一ディレクトリに `status: active` な `PLAN.md` があれば、`.md` を全部免除していた。`.claude/artifacts/plans/` はディレクトリ単位一致のため、`plans/` 直下に誤配置された stale な `PLAN.md` があると `plans/` 配下全ファイルが恒久的に免除されるバグがあった(downstream の tepra プロジェクトで実害確認: 完了済み spec 12件が長期未検知)。
- 修正: `plans/` (任意の深さ) は常に reject 対象とし、他の task-slug dir (`.claude/artifacts/<task-slug>/`) にのみ従来のローカル免除を適用。
- 副次対応: 完了済み `2026-07-08-test-coverage-100.md` spec を `docs/specs/architecture/testing.md`(新規)/ `docs/specs/components/brust-web.md` へ吸収し削除。進行中の `grapesjs-wireframe` spec/PLAN/notes は規約通り `.claude/artifacts/grapesjs-wireframe/` へ移動(上記修正により `plans/` 直下に置いたままだと恒久的にブロックされるため)。
- 別コミットで `.gitignore` の deps-sync 生成物 glob パターン不備も修正(無関係な既存差分の同梱)。
- `pre-push` が `test`(stable)と `coverage`(nightly、instrumented)の両方に依存し、フルテストスイートを二重実行して `target/` ディスク使用量を倍増させていた問題を修正。`coverage` は既に nextest フルスイートを実行するため `test` 依存を除外。併せて `coverage` 実行後の `target/llvm-cov-target` を EXIT trap で自動削除し、4タスクで重複していたスレッド数計算・quiet フラグ判定ロジックを `.mise/lib/nextest-env.sh` へ集約。新規ファイルは `.github/graft/config.yaml` の manifest に登録し fork 先リポジトリへの同期漏れを防止。

## Test plan

- [x] `mise run check:no-plans` — nested task-slug dir / plans/ 直下ファイルで期待通り reject されることを個別検証
- [x] `mise run pre-commit` — 全項目 PASS
- [x] `mise run pre-push` — coverage 実行(77 tests, 1回のみ)含め全項目 PASS
- [x] code-reviewer agent review — P0/P1/P2 なし
- [x] `cargo llvm-cov clean`(no `--workspace`)で `target/llvm-cov-target` が実際に削除されることを `du` で実測検証

https://claude.ai/code/session_01WU1zdePQNmfGVLb9LWuUrD