### PR TITLE
fix(ci): cache nightly rustup toolchain used by coverage/miri

### DIFF
--- a/.github/actions/act-setup-rust/action.yaml
+++ b/.github/actions/act-setup-rust/action.yaml
@@ -30,7 +30,13 @@ runs:
         path: |
           ~/.rustup/settings.toml
           ~/.rustup/toolchains/1.*
-        key: v0-rust-rustup-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/rust-toolchain.toml') }}
+          ~/.rustup/toolchains/nightly-*
+        # `.mise/tasks.toml` hash is included because it's the sole source of
+        # the pinned nightly toolchain version (`nightly-YYYY-MM-DD`, used by
+        # the `coverage`/`miri` tasks) — `rust-toolchain.toml` only pins the
+        # stable channel, so it wouldn't invalidate this cache on a nightly
+        # bump.
+        key: v0-rust-rustup-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/rust-toolchain.toml', '.mise/tasks.toml') }}
 
     - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
       with:

--- a/.mise/lib/nextest-env.sh
+++ b/.mise/lib/nextest-env.sh
@@ -4,7 +4,16 @@
 # four separate `run` scripts.
 _cpus=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
 _threads=$(( _cpus * 7 / 10 < 1 ? 1 : _cpus * 7 / 10 ))
-[[ "${GITHUB_ACTIONS:-}" == "true" ]] && _threads="$_cpus"
+# `if` (not `[[ ]] && ...`) — under `set -e` in the sourcing caller, a false
+# `&&` expression as this script's last-executed statement would make
+# `source` itself return 1, silently aborting the caller before any test
+# ever runs. `if` always returns 0 regardless of the condition's outcome.
+if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+  _threads="$_cpus"
+fi
 
 _quiet=""
-[[ "${CLAUDECODE:-}" == "1" ]] && _quiet="--cargo-quiet --cargo-quiet --status-level fail"
+# Same set -e/source gotcha as above — keep as `if`, not `[[ ]] && ...`.
+if [[ "${CLAUDECODE:-}" == "1" ]]; then
+  _quiet="--cargo-quiet --cargo-quiet --status-level fail"
+fi


### PR DESCRIPTION
## 概要

CI の coverage ジョブが失敗する原因を切り分けた結果、独立した 2 つの問題を発見・修正しました。

## 変更内容

### 1. rustup nightly toolchain のキャッシュ拡張

`rustup component add llvm-tools-preview --toolchain nightly-2026-03-15` が CI で断続的に失敗するインフラフレークを調査した結果、nightly toolchain が毎回ネットワーク再ダウンロードされていたことが原因と判明しました。

- 既存の rustup キャッシュ(`act-setup-rust`)は `~/.rustup/toolchains/1.*` のみを対象としており、`nightly-2026-03-15-*` にマッチしないため nightly は一度もキャッシュされていませんでした。
- `path` に `~/.rustup/toolchains/nightly-*` を追加。
- `key` の `hashFiles(...)` に `.mise/tasks.toml` を追加(nightly バージョンの唯一の出所であるため)。

### 2. `.mise/lib/nextest-env.sh` の silent-abort バグ修正

上記のキャッシュ修正を検証中、ユーザー実環境で `mise run coverage` が常に「ERROR task failed」のみで詳細不明のまま失敗する事象が発覚し、別のバグと判明しました。

- 共有スクリプトの最終行が `[[ "${CLAUDECODE:-}" == "1" ]] && _quiet="..."` だったため、CLAUDECODE 未設定(通常のターミナル)では `source` 自体の終了コードが 1 になり、呼び出し側の `set -euo pipefail` で test/coverage タスクがエラーメッセージ一切なしに即死していました。
- Claude Code セッションは常に `CLAUDECODE=1` が設定されるため、エージェント経由の事前検証では一度も表面化せず、人間デベロッパーのターミナルでのみ再現していました。
- rustup 側の障害が解消した後には CI でも必ず顕在化する状態だったため、同一 PR で修正しました。
- `[[ cond ]] && var=...` を `if [[ cond ]]; then var=...; fi` に置換。

## Test plan

- [x] `mise run pre-commit` 通過(両コミット)
- [x] `mise run pre-push`(coverage 実行含む)通過、Lines 97.01%
- [x] ユーザー実環境(CLAUDECODE 未設定)で `mise run coverage` 正常実行を確認
- [ ] CI(GitHub Actions)全 job 通過確認

https://claude.ai/code/session_01WU1zdePQNmfGVLb9LWuUrD