### PR TITLE
update(mise): background web:serve with auto stop-and-restart

### DIFF
--- a/.mise/tasks.toml
+++ b/.mise/tasks.toml
@@ -568,8 +568,55 @@ echo "wireframe stopped"
 """
 
 ["web:serve"]
-description = "Start brust-web dev server"
-run = 'cargo run -p brust-web -- serve --bind 0.0.0.0:3000'
+description = "Start brust-web dev server in background (restarts if already running)"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+
+_pidfile="/tmp/brust-web.pid"
+
+# Build first: if this fails, the old server (if any) keeps running instead
+# of leaving the user with no server at all.
+cargo build -p brust-web
+
+# Stop any already-running instance so the latest build always wins.
+# Delegates to web:stop instead of re-inlining the TERM->wait->KILL sequence.
+if [ -f "$_pidfile" ] && kill -0 "$(cat "$_pidfile")" 2>/dev/null; then
+  echo "brust-web already running (pid $(cat "$_pidfile")), restarting..."
+  mise run web:stop
+fi
+
+_root="$(pwd)"
+setsid bash -c "cd '${_root}' && cargo run -p brust-web -- serve --bind 0.0.0.0:3000" \
+  >/tmp/brust-web.log 2>&1 &
+echo $! > "$_pidfile"
+
+timeout 30 bash -c 'until curl -sf --max-time 1 http://localhost:3000/health >/dev/null 2>&1; do sleep 0.3; done' \
+  || { echo "Error: brust-web failed to become ready (see /tmp/brust-web.log)" >&2; exit 1; }
+echo "brust-web started (http://localhost:3000, pid $(cat "$_pidfile"))"
+"""
+
+["web:stop"]
+description = "Stop brust-web dev server"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+
+_pidfile="/tmp/brust-web.pid"
+if [ ! -f "$_pidfile" ]; then
+  echo "brust-web not running (no pidfile)"
+  exit 0
+fi
+_pid=$(cat "$_pidfile")
+if kill -0 "$_pid" 2>/dev/null; then
+  # kill process group to reap child cargo/binary processes spawned by setsid
+  kill -TERM -"$_pid" 2>/dev/null || kill -TERM "$_pid" 2>/dev/null || true
+  for _ in $(seq 1 20); do kill -0 "$_pid" 2>/dev/null || break; sleep 0.1; done
+  kill -0 "$_pid" 2>/dev/null && kill -KILL -"$_pid" 2>/dev/null || true
+fi
+rm -f "$_pidfile"
+echo "brust-web stopped"
+"""
 
 ["setup:playwright"]
 description = "Install @playwright/mcp deps and download Chromium browser"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ All tasks use `mise run <task>`:
 | Dev (status)          | `mise run dev:status`         |
 | Traefik setup         | `mise run traefik:setup`      |
 | Web server (start)    | `mise run web:serve`          |
+| Web server (stop)     | `mise run web:stop`           |
 | Wireframe (start)     | `mise run wireframe:up`       |
 | Wireframe (stop)      | `mise run wireframe:down`     |
 


### PR DESCRIPTION
## 概要

`mise run web:serve` がフォアグラウンド実行専用だったため `:3000` を占有し、Claude Code がコードを変更しても既存プロセスが古いバージョンを起動しっぱなしになる問題を解消する。

- `web:serve` 実行時: 起動確認 → 起動中なら stop → 再起動、未起動ならそのまま起動。いずれもバックグラウンド(`setsid`)起動。
- ビルドは stop の前に実行(ビルド失敗時は旧サーバを継続稼働させ、無サーバ状態を避ける)。
- 起動完了待機は `/health` エンドポイントへの `curl` ポーリング(`wireframe:up` と同パターン)。
- `web:stop` を新規追加(`wireframe:down` と同パターン)。バックグラウンド化で Ctrl-C による停止ができなくなるため、明示的な停止手段として追加。`web:serve` の再起動分岐は重複実装を避けて `web:stop` を呼び出す構成。
- `CLAUDE.md` のコマンドテーブルに `Web server (stop)` 行を追加。

## Test plan

- [x] `mise run web:serve` 初回起動 → `/health` 応答確認、バックグラウンド稼働確認
- [x] `mise run web:serve` 再実行 → 旧 PID 終了・新 PID で再起動確認
- [x] `mise run web:stop` → プロセス完全終了確認(`/health` へのリクエストが接続拒否)
- [x] コンパイルエラー注入テスト → ビルド失敗時は旧サーバが生存し続けることを確認
- [x] `mise run pre-commit` 全通過
- [x] `git push` の pre-push フック(coverage含む)全通過
