### PR TITLE
update(cargo): shrink dev profile debug info to line-tables-only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,10 +186,10 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 # -
 [profile.dev]
 opt-level = 1 #										Improving debug execution speed (balancing it with compilation time)
-debug = 2 #											Full debugging information for workspace members
+debug = "line-tables-only" #						File:line info for backtraces/panics only, no type/variable info (size reduction; gdb variable inspection not used).
 
 [profile.dev.package."*"]
-debug = 1 #											External dependencies are limited to line tables only (size reduction).
+debug = "line-tables-only" #						Same as above for external dependencies (size reduction).
 
 [profile.release]
 strip = "debuginfo" #								Remove DWARF files, but keep the symbol table (.symtab).


### PR DESCRIPTION
## Summary
- `[profile.dev]` と `[profile.dev.package."*"]` の `debug` 設定を `"line-tables-only"` に変更
- target/debug が full DWARF debug info (debug=2 workspace / debug=1 deps) に加え、stable + nightly の二重ツールチェーン使用でサイズが肥大化していた問題を軽減
- OTel span の file:line はコンパイル時 `file!()`/`line!()` マクロ展開で決まり、anyhow/panic のバックトレース解決も DWARF line table のみで足りる（型/変数情報は不要）ため、observability への影響なし

## Verification
- [x] `mise run test`（77件）通過
- [x] `mise run pre-commit`（zizmor / fmt / clippy:strict / ast-grep / lint:gh / check:no-plans / test）通過
- [x] A/B 検証: `target/debug` が 1.1G → 892M（約19%削減）、`target/` 削除後の再ビルドでも再現
- [x] code-reviewer エージェントレビュー: PASS（blocking指摘なし、P2/P3の情報提供のみ）

https://claude.ai/code/session_013bX18ScQ8q8PVqs9wPYoQN